### PR TITLE
[GOMO-25] 예외 공통 처리

### DIFF
--- a/src/main/java/com/gomo/app/common/exception/DomainExceptionAdvice.java
+++ b/src/main/java/com/gomo/app/common/exception/DomainExceptionAdvice.java
@@ -1,0 +1,29 @@
+package com.gomo.app.common.exception;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class DomainExceptionAdvice {
+
+	@ExceptionHandler(DomainException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(DomainException e, HttpServletRequest request) {
+		log.warn("[Domain exception occurred!] code: {}, message: {}", e.getCode(), e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(
+			LocalDateTime.now(),
+			e.getHttpStatus(),
+			e.getCode(),
+			e.getMessage(),
+			request.getRequestURI()
+		);
+
+		return ResponseEntity.status(e.getHttpStatus()).body(errorResponse);
+	}
+}

--- a/src/main/java/com/gomo/app/interest/domain/model/InterestName.java
+++ b/src/main/java/com/gomo/app/interest/domain/model/InterestName.java
@@ -1,8 +1,11 @@
 package com.gomo.app.interest.domain.model;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
+
 import java.util.regex.Pattern;
 
 import com.gomo.app.common.domain.ValueObject;
+import com.gomo.app.common.exception.PolicyViolationException;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
@@ -37,24 +40,24 @@ public class InterestName {
 
 	private void ensureNotNull(String interestName) {
 		if(interestName == null) {
-			throw new IllegalArgumentException("Interest name cannot be null");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Interest name cannot be null");
 		}
 	}
 
 	private void ensureValidLength(String interestName) {
 		int length = interestName.length();
 		if(length < MIN_LENGTH) {
-			throw new IllegalArgumentException("Interest name is too short");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Interest name is too short");
 		}
 
 		if(length > MAX_LENGTH) {
-			throw new IllegalArgumentException("Interest name is too long");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Interest name is too long");
 		}
 	}
 
 	private void ensureNoForbiddenName(String interestName) {
 		if(FORBIDDEN_PATTERN.matcher(interestName).find()) {
-			throw new IllegalArgumentException("Interest name cannot contain forbidden characters");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Interest name cannot contain forbidden characters");
 		}
 	}
 

--- a/src/main/java/com/gomo/app/interest/domain/model/Level.java
+++ b/src/main/java/com/gomo/app/interest/domain/model/Level.java
@@ -1,7 +1,8 @@
 package com.gomo.app.interest.domain.model;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
+
 import com.gomo.app.common.domain.ValueObject;
-import com.gomo.app.common.exception.DomainErrorCode;
 import com.gomo.app.common.exception.PolicyViolationException;
 
 import jakarta.persistence.Embeddable;
@@ -49,19 +50,19 @@ public class Level {
 
 	private void ensurePositive(int increment) {
 		if(increment <= 0) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Level increment must be positive.");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Level increment must be positive.");
 		}
 	}
 
 	private void ensureNotNegative(int level) {
 		if(level < 0) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Level must be positive or zero.");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Level must be positive or zero.");
 		}
 	}
 
 	private void ensureNotExceedMaximum(int level) {
 		if(level > MAXIMUM_LEVEL) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Level cannot exceed the maximum level.");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Level cannot exceed the maximum level.");
 		}
 	}
 

--- a/src/main/java/com/gomo/app/interest/domain/model/Score.java
+++ b/src/main/java/com/gomo/app/interest/domain/model/Score.java
@@ -1,7 +1,8 @@
 package com.gomo.app.interest.domain.model;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
+
 import com.gomo.app.common.domain.ValueObject;
-import com.gomo.app.common.exception.DomainErrorCode;
 import com.gomo.app.common.exception.PolicyViolationException;
 
 import jakarta.persistence.Embeddable;
@@ -53,7 +54,7 @@ public class Score {
 
 	private void validatePositive(int increment) {
 		if(increment <= 0) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Score increment must be positive.");
+			throw new PolicyViolationException(INVALID_PARAMETER, "Score increment must be positive.");
 		}
 	}
 

--- a/src/main/java/com/gomo/app/interest/domain/model/ScoreThreshold.java
+++ b/src/main/java/com/gomo/app/interest/domain/model/ScoreThreshold.java
@@ -1,7 +1,8 @@
 package com.gomo.app.interest.domain.model;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
+
 import com.gomo.app.common.domain.ValueObject;
-import com.gomo.app.common.exception.DomainErrorCode;
 import com.gomo.app.common.exception.PolicyViolationException;
 
 import jakarta.persistence.AttributeOverride;
@@ -60,7 +61,7 @@ public class ScoreThreshold {
 
 		private LevelRange(int min, int max) {
 			if (min > max) {
-				throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Min level cannot be greater than max level");
+				throw new PolicyViolationException(INVALID_PARAMETER, "Min level cannot be greater than max level");
 			}
 
 			this.min = min;

--- a/src/main/java/com/gomo/app/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/gomo/app/member/exception/MemberErrorCode.java
@@ -9,7 +9,6 @@ public enum MemberErrorCode {
 	EMAIL_DUPLICATED("Email already exists: ", 409),
 	HANDLE_DUPLICATED("Handle already exists: ", 409),
 	AUTHENTICATION_FAILED("Member Authentication fail", 401),
-	INVALID_PARAMETER("Invalid parameter: ", 422),
 	PROFILE_IMAGE_TOO_LARGE("Profile image size too large", 413),
 	QUEST_PROPERTY_UPDATE_NOT_ALLOWED("Quest property must be within the range, but: ", 422);
 

--- a/src/test/java/com/gomo/app/common/constant/ErrorResponseFields.java
+++ b/src/test/java/com/gomo/app/common/constant/ErrorResponseFields.java
@@ -9,7 +9,7 @@ public interface ErrorResponseFields {
 
 	Snippet RESPONSE_FIELDS = responseFields(
 		fieldWithPath("timestamp").type(JsonFieldType.STRING).description("에러 발생 시간"),
-		fieldWithPath("httpStatus").type(JsonFieldType.STRING).description("http 응답 상태 코드"),
+		fieldWithPath("httpStatus").type(JsonFieldType.NUMBER).description("http 응답 상태 코드"),
 		fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드"),
 		fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메시지"),
 		fieldWithPath("path").type(JsonFieldType.STRING).description("요청 url")

--- a/src/test/java/com/gomo/app/interest/documentation/CreateInterestDocumentationTest.java
+++ b/src/test/java/com/gomo/app/interest/documentation/CreateInterestDocumentationTest.java
@@ -1,5 +1,6 @@
 package com.gomo.app.interest.documentation;
 
+import static com.gomo.app.interest.exception.InterestErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpHeaders.*;
@@ -22,7 +23,6 @@ import com.gomo.app.common.exception.DomainErrorCode;
 import com.gomo.app.common.util.LoginMemberHelper;
 import com.gomo.app.interest.common.util.InterestDataHelper;
 import com.gomo.app.interest.documentation.snippet.CreateInterestSnippet;
-import com.gomo.app.interest.exception.InterestErrorCode;
 import com.gomo.app.interest.presentation.request.CreateInterestRequest;
 
 @DisplayName("[Presentation documentation]: 관심사 생성 테스트")
@@ -97,8 +97,8 @@ public class CreateInterestDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(PAYLOAD_TOO_LARGE.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("413"))
-			.body("code", equalTo(InterestErrorCode.LOGO_IMAGE_TOO_LARGE.name()))
+			.body("httpStatus", equalTo(LOGO_IMAGE_TOO_LARGE.getHttpStatus()))
+			.body("code", equalTo(LOGO_IMAGE_TOO_LARGE.name()))
 			.body("message", equalTo("Logo image size too large"))
 			.body("path", equalTo(INTEREST_URL));
 	}

--- a/src/test/java/com/gomo/app/interest/documentation/UpdateInterestDocumentationTest.java
+++ b/src/test/java/com/gomo/app/interest/documentation/UpdateInterestDocumentationTest.java
@@ -1,5 +1,6 @@
 package com.gomo.app.interest.documentation;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpHeaders.*;
@@ -14,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 import com.gomo.app.common.DocumentationTestBase;
-import com.gomo.app.common.exception.DomainErrorCode;
 import com.gomo.app.common.util.LoginMemberHelper;
 import com.gomo.app.interest.common.dataprovider.InterestDataProvider;
 import com.gomo.app.interest.common.util.InterestDataHelper;
@@ -67,15 +67,15 @@ public class UpdateInterestDocumentationTest extends DocumentationTestBase {
 	void update_interest_with_invalid_name() {
 		given(this.specification).filter(errorFilter)
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-			.body(UpdateInterestRequest.of("forbidden #{}!"))
+			.body(UpdateInterestRequest.of("forbidden{}"))
 			.when()
-			.put(INTEREST_URL, interest.getId())
+			.put(INTEREST_URL, interest.getId().getId())
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
-			.body("code", equalTo(DomainErrorCode.INVALID_PARAMETER.name()))
-			.body("message", equalTo("Invalid parameter: forbidden #{}!"))
-			.body("path", equalTo(INTEREST_URL));
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
+			.body("code", equalTo(INVALID_PARAMETER.name()))
+			.body("message", equalTo("Interest name cannot contain forbidden characters"))
+			.body("path", matchesRegex("/interests/[a-f0-9\\-]{36}"));
 	}
 }

--- a/src/test/java/com/gomo/app/interest/unit/domain/InterestNameTest.java
+++ b/src/test/java/com/gomo/app/interest/unit/domain/InterestNameTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.gomo.app.common.exception.PolicyViolationException;
 import com.gomo.app.interest.domain.model.InterestName;
 
 @DisplayName("[Domain unit]: 관심사 이름 생성 및 수정 테스트")
@@ -31,7 +32,7 @@ public class InterestNameTest {
 	@Test
 	void create_interest_name_with_null() {
 		assertThatThrownBy(() -> InterestName.of(null))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name cannot be null");
 	}
 
@@ -39,7 +40,7 @@ public class InterestNameTest {
 	@Test
 	void create_interest_name_with_short_name() {
 		assertThatThrownBy(() -> InterestName.of(TOO_SHORT_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name is too short");
 	}
 
@@ -47,7 +48,7 @@ public class InterestNameTest {
 	@Test
 	void create_interest_name_with_long_name() {
 		assertThatThrownBy(() -> InterestName.of(TOO_LONG_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name is too long");
 	}
 
@@ -55,7 +56,7 @@ public class InterestNameTest {
 	@Test
 	void create_interest_name_with_forbidden_characters() throws Exception {
 		assertThatThrownBy(() -> InterestName.of(FORBIDDEN_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name cannot contain forbidden characters");
 	}
 
@@ -74,7 +75,7 @@ public class InterestNameTest {
 		InterestName interestName = InterestName.of(NAME_PARAM);
 
 		assertThatThrownBy(() -> interestName.update(null))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name cannot be null");
 	}
 
@@ -84,7 +85,7 @@ public class InterestNameTest {
 		InterestName interestName = InterestName.of(NAME_PARAM);
 
 		assertThatThrownBy(() -> interestName.update(TOO_SHORT_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name is too short");
 	}
 
@@ -94,7 +95,7 @@ public class InterestNameTest {
 		InterestName interestName = InterestName.of(NAME_PARAM);
 
 		assertThatThrownBy(() -> interestName.update(TOO_LONG_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name is too long");
 	}
 
@@ -104,7 +105,7 @@ public class InterestNameTest {
 		InterestName interestName = InterestName.of(NAME_PARAM);
 
 		assertThatThrownBy(() -> interestName.update(FORBIDDEN_NAME))
-			.isInstanceOf(IllegalArgumentException.class)
+			.isInstanceOf(PolicyViolationException.class)
 			.hasMessageContaining("Interest name cannot contain forbidden characters");
 	}
 }

--- a/src/test/java/com/gomo/app/member/documentation/CheckDuplicatedHandleDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/CheckDuplicatedHandleDocumentationTest.java
@@ -1,6 +1,6 @@
 package com.gomo.app.member.documentation;
 
-import static com.gomo.app.member.exception.MemberErrorCode.*;
+import static com.gomo.app.common.exception.DomainErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpStatus.*;
@@ -72,7 +72,7 @@ public class CheckDuplicatedHandleDocumentationTest extends DocumentationTestBas
 			.then()
 			.statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + SHORT_HANDLE))
 			.body("path", equalTo(DUPLICATED_HANDLE_URL));

--- a/src/test/java/com/gomo/app/member/documentation/CreateEmailAuthCodeDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/CreateEmailAuthCodeDocumentationTest.java
@@ -1,5 +1,6 @@
 package com.gomo.app.member.documentation;
 
+import static com.gomo.app.common.exception.DomainErrorCode.INVALID_PARAMETER;
 import static com.gomo.app.member.exception.MemberErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
@@ -67,7 +68,7 @@ public class CreateEmailAuthCodeDocumentationTest extends DocumentationTestBase 
 			.then()
 			.statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + INVALID_EMAIL))
 			.body("path", equalTo(EMAIL_AUTH_URL));

--- a/src/test/java/com/gomo/app/member/documentation/SignUpMemberDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/SignUpMemberDocumentationTest.java
@@ -1,7 +1,7 @@
 package com.gomo.app.member.documentation;
 
+import static com.gomo.app.common.exception.DomainErrorCode.*;
 import static com.gomo.app.member.common.constant.NonExistMemberField.*;
-import static com.gomo.app.member.exception.MemberErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpStatus.*;
@@ -83,7 +83,7 @@ public class SignUpMemberDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + SHORT_PASSWORD.length()))
 			.body("path", equalTo(MEMBER_URL));

--- a/src/test/java/com/gomo/app/member/documentation/UpdateHandleDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/UpdateHandleDocumentationTest.java
@@ -1,5 +1,6 @@
 package com.gomo.app.member.documentation;
 
+import static com.gomo.app.common.exception.DomainErrorCode.INVALID_PARAMETER;
 import static com.gomo.app.member.exception.MemberErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
@@ -91,7 +92,7 @@ public class UpdateHandleDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + INVALID_HANDLE))
 			.body("path", equalTo(HANDLE_URL));

--- a/src/test/java/com/gomo/app/member/documentation/UpdateMemberInfoDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/UpdateMemberInfoDocumentationTest.java
@@ -1,6 +1,6 @@
 package com.gomo.app.member.documentation;
 
-import static com.gomo.app.member.exception.MemberErrorCode.*;
+import static com.gomo.app.common.exception.DomainErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.http.HttpStatus.*;
@@ -75,7 +75,7 @@ public class UpdateMemberInfoDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + INVALID_NAME))
 			.body("path", equalTo(MEMBER_URL));
@@ -93,7 +93,7 @@ public class UpdateMemberInfoDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + INVALID_MOTTO))
 			.body("path", equalTo(MEMBER_URL));

--- a/src/test/java/com/gomo/app/member/documentation/UpdatePasswordDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/UpdatePasswordDocumentationTest.java
@@ -1,5 +1,6 @@
 package com.gomo.app.member.documentation;
 
+import static com.gomo.app.common.exception.DomainErrorCode.INVALID_PARAMETER;
 import static com.gomo.app.member.exception.MemberErrorCode.*;
 import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
@@ -15,12 +16,12 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 import com.gomo.app.common.DocumentationTestBase;
-import com.gomo.app.common.util.LoginMemberHelper;
 import com.gomo.app.common.fixture.TestMemberFixture;
+import com.gomo.app.common.util.LoginMemberHelper;
+import com.gomo.app.member.common.constant.NonExistMemberField;
+import com.gomo.app.member.common.util.MemberDBDataHelper;
 import com.gomo.app.member.documentation.snippet.UpdatePasswordSnippet;
 import com.gomo.app.member.presentation.request.UpdatePasswordRequest;
-import com.gomo.app.member.common.util.MemberDBDataHelper;
-import com.gomo.app.member.common.constant.NonExistMemberField;
 
 public class UpdatePasswordDocumentationTest extends DocumentationTestBase {
 
@@ -92,7 +93,7 @@ public class UpdatePasswordDocumentationTest extends DocumentationTestBase {
 			.then()
 			.statusCode(UNPROCESSABLE_ENTITY.value())
 			.body("timestamp", instanceOf(String.class))
-			.body("httpStatus", equalTo("422"))
+			.body("httpStatus", equalTo(INVALID_PARAMETER.getHttpStatus()))
 			.body("code", equalTo(INVALID_PARAMETER.name()))
 			.body("message", equalTo("Invalid parameter: " + INVALID_PASSWORD))
 			.body("path", equalTo(PASSWORD_URL));


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** [#GOMO-25](https://kkj1250.atlassian.net/jira/software/projects/GOMO/boards/2/timeline?selectedIssue=GOMO-25)

<br>

### 내용

- [X] `RestControllerAdvice`를 활용해 예외 공통 처리
- [X] 자바 표준 예외를 도메인 공통 예외로 변경
- [X] 테스트 수정