### PR TITLE
[GOMO-79] 퀘스트 완료 기능 수정

### DIFF
--- a/src/main/java/com/gomo/app/quest/domain/model/AssignQuest.java
+++ b/src/main/java/com/gomo/app/quest/domain/model/AssignQuest.java
@@ -95,9 +95,9 @@ public class AssignQuest extends BaseAudit implements OrderChangeable, Authoriza
 	}
 
 	public void complete(CompletionProof proof, LocalDateTime completedDateTime) {
-		if(!this.isConfirmed) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_STATE, "AssignQuest must be confirmed before completing");
-		}
+		ensureConfirmed();
+		ensureNotCompleted();
+
 		this.isCompleted = true;
 		this.proof = proof;
 		this.displayOrder = this.displayOrder.increase(1000);
@@ -120,6 +120,18 @@ public class AssignQuest extends BaseAudit implements OrderChangeable, Authoriza
 	public void validateAuthority(UUID accessorId) {
 		if(!this.quest.isAccessibleBy(accessorId)) {
 			throw new AssignQuestAccessDeniedException(AssignQuestErrorCode.ACCESS_DENIED);
+		}
+	}
+
+	private void ensureConfirmed() {
+		if(!this.isConfirmed) {
+			throw new PolicyViolationException(DomainErrorCode.INVALID_STATE, "AssignQuest must be confirmed before completing");
+		}
+	}
+
+	private void ensureNotCompleted() {
+		if(this.isCompleted) {
+			throw new PolicyViolationException(DomainErrorCode.INVALID_STATE, "AssignQuest has already been completed");
 		}
 	}
 }

--- a/src/test/java/com/gomo/app/quest/unit/domain/AssignQuestTest.java
+++ b/src/test/java/com/gomo/app/quest/unit/domain/AssignQuestTest.java
@@ -178,6 +178,25 @@ public class AssignQuestTest {
 			.hasMessageContaining("AssignQuest must be confirmed before completing");
 	}
 
+	@DisplayName("이미 완료된 퀘스트는 중복해서 완료할 수 없다.")
+	@Test
+	void complete_assign_quest_with_completed_assign_quest() {
+		AssignQuest assignQuest = AssignQuest.of(
+			ID,
+			Quest.of(PARTICIPANT_ID, SUBJECT_ID, SUBJECT_NAME, QuestType.DAILY, QUEST_CONTENT),
+			true,
+			DisplayOrder.of(1),
+			LocalDateTime.of(2025, 1, 31, 0, 0, 0, 0)
+		);
+
+		CompletionProof updatedProof = CompletionProof.of("updated proof");
+		assignQuest.complete(updatedProof, NOW);
+
+		assertThatThrownBy(() -> assignQuest.complete(updatedProof, NOW))
+			.isInstanceOf(PolicyViolationException.class)
+			.hasMessageContaining("AssignQuest has already been completed");
+	}
+
 	@DisplayName("할당 퀘스트의 타입을 같은 타입과 비교한다.")
 	@Test
 	void quest_type_is_same_assign_quest_type() {


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** [#GOMO-79](https://kkj1250.atlassian.net/jira/software/projects/GOMO/boards/2/timeline?selectedIssue=GOMO-79)

<br>

### 내용

#### ❗ 퀘스트 중복 완료 방지
- [X] 이미 완료된 퀘스트는 중복해서 완료할 수 없도록 수정했습니다.
- [X] 테스트 코드를 작성했습니다.