### PR TITLE
[GOMO-78]  회원 가입 기능 로직 보완

### DIFF
--- a/src/main/java/com/gomo/app/common/configuration/SMTPConfiguration.java
+++ b/src/main/java/com/gomo/app/common/configuration/SMTPConfiguration.java
@@ -11,9 +11,9 @@ import java.util.Properties;
 @Configuration
 public class SMTPConfiguration {
 
-    @Value("{spring.mail.host}") private String HOST;
-    @Value("{spring.mail.username}") private String USERNAME;
-    @Value("{spring.mail.password}") private String PASSWORD;
+    @Value("${spring.mail.host}") private String HOST;
+    @Value("${spring.mail.username}") private String USERNAME;
+    @Value("${spring.mail.password}") private String PASSWORD;
 
     @Bean
     public JavaMailSender mailSender(){

--- a/src/main/java/com/gomo/app/member/application/CreateMemberUseCase.java
+++ b/src/main/java/com/gomo/app/member/application/CreateMemberUseCase.java
@@ -5,6 +5,7 @@ import com.gomo.app.common.util.UUIDGenerator;
 import com.gomo.app.member.domain.model.Member;
 import com.gomo.app.member.domain.model.MemberId;
 import com.gomo.app.member.domain.repository.MemberRepository;
+import com.gomo.app.member.domain.service.MemberValidator;
 import com.gomo.app.member.domain.service.PasswordService;
 import com.gomo.app.member.presentation.request.CreateMemberRequest;
 import com.gomo.app.member.presentation.response.CreateMemberResponse;
@@ -24,10 +25,14 @@ import java.util.UUID;
 public class CreateMemberUseCase {
 
     private final MemberRepository memberRepository;
+    private final MemberValidator memberValidator;
     private final PointWalletRepository pointWalletRepository;
     private final PasswordService passwordService;
 
     public CreateMemberResponse create(CreateMemberRequest request) {
+        memberValidator.checkDuplicatedEmail(request.getEmail());
+        memberValidator.checkDuplicatedHandle(request.getHandle());
+
         UUID member_uuid = UUIDGenerator.generate();
         MemberId memberId = MemberId.of(member_uuid);
         Member member = request.toDomain(memberId, passwordService);

--- a/src/main/java/com/gomo/app/member/domain/model/Handle.java
+++ b/src/main/java/com/gomo/app/member/domain/model/Handle.java
@@ -38,7 +38,6 @@ public class Handle {
         if(this.handle.equals(handle)){
             throw new PolicyViolationException(INVALID_PARAMETER, "Handle is already same");
         }
-
         return Handle.of(handle);
     }
 

--- a/src/test/java/com/gomo/app/member/unit/usecase/CreateMemberUseCaseTest.java
+++ b/src/test/java/com/gomo/app/member/unit/usecase/CreateMemberUseCaseTest.java
@@ -3,6 +3,12 @@ package com.gomo.app.member.unit.usecase;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.gomo.app.common.util.UUIDGenerator;
+import com.gomo.app.member.domain.service.MemberValidator;
+import com.gomo.app.point.domain.model.PointWallet;
+import com.gomo.app.point.domain.model.PointWalletId;
+import com.gomo.app.point.domain.model.TransactorId;
+import com.gomo.app.point.domain.repository.PointWalletRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +25,8 @@ import com.gomo.app.member.domain.service.PasswordService;
 import com.gomo.app.member.presentation.request.CreateMemberRequest;
 import com.gomo.app.member.presentation.response.CreateMemberResponse;
 
+import java.util.UUID;
+
 @DisplayName("[Application Unit]: 멤버 생성 테스트")
 @ExtendWith(MockitoExtension.class)
 public class CreateMemberUseCaseTest {
@@ -30,21 +38,31 @@ public class CreateMemberUseCaseTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private MemberValidator memberValidator;
+
+    @Mock
     private PasswordService passwordService;
+
+    @Mock
+    private PointWalletRepository pointWalletRepository;
 
     @BeforeEach
     void setUp() {
         when(passwordService.encode("Test123!")).thenReturn("Encode123!");
     }
 
-    // TODO <jhl221123 to nurdykim>: 회원 생성 로직 수정 후, 테스트 수정이 안되었던 것 같습니다.
     @DisplayName("회원을 등록한다.")
     @Test
     void create_member(){
         Member member = MemberFixture.member(passwordService);
+        UUID pointwallet_uuid = UUIDGenerator.generate();
+        PointWallet pointWallet = PointWallet.createDefault(PointWalletId.of(pointwallet_uuid), TransactorId.of(member.getId().getId()));
         CreateMemberResponse expected = CreateMemberResponse.of(member.getId());
 
+        doNothing().when(memberValidator).checkDuplicatedEmail(any());
+        doNothing().when(memberValidator).checkDuplicatedHandle(any());
         doReturn(member).when(memberRepository).save(any(Member.class));
+        doReturn(pointWallet).when(pointWalletRepository).save(any(PointWallet.class));
 
         CreateMemberResponse actual = sut.create(
                 CreateMemberRequest.of(


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** #[GOMO-78](https://kkj1250.atlassian.net/browse/GOMO-78?atlOrigin=eyJpIjoiYzIxYzRjYmMxNzczNDRhMTkwMTM4OGZmMWE4ZTVmN2EiLCJwIjoiaiJ9)

<br>

### 내용

**이메일 인증코드가 발송되지 않던 문제 수정**
- [x] 이메일 인증에 필요한 상수가 주입되지 않던 문제를 수정하였습니다.

**회원가입 시, 이메일과 핸들 검증 로직이 누락된 문제 수정**
- [x] 회원 가입 시 핸들 중복 확인 로직 추가 하였습니다.
- [x] 회원 가입 시 이메일 중복 확인 로직 추가 하였습니다.

**회원가입 관련 테스트 오류 수정**
- [x] PointWallet 등 로직 변경에따라 추가된 부분을 Mocking 처리하여 정상적으로 테스트 처리되도록 수정하였습니다.

[GOMO-78]: https://kkj1250.atlassian.net/browse/GOMO-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ