### PR TITLE
[GOMO-110] 관심사 조회 스펙 변경

### DIFF
--- a/src/main/java/com/gomo/app/interest/application/ReadInterestNetworkUseCase.java
+++ b/src/main/java/com/gomo/app/interest/application/ReadInterestNetworkUseCase.java
@@ -2,11 +2,14 @@ package com.gomo.app.interest.application;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 import com.gomo.app.common.application.ApplicationService;
+import com.gomo.app.common.util.JsonParser;
 import com.gomo.app.interest.domain.model.RegistrantId;
 import com.gomo.app.interest.domain.repository.InterestRelationRepository;
 import com.gomo.app.interest.domain.repository.InterestRepository;
+import com.gomo.app.interest.domain.repository.MajorInterestRepository;
 import com.gomo.app.interest.presentation.response.InterestNetworkResponse;
 import com.gomo.app.interest.presentation.response.ReadInterestRelationResponse;
 import com.gomo.app.interest.presentation.response.ReadInterestResponse;
@@ -18,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class ReadInterestNetworkUseCase {
 
 	private final InterestRepository interestRepository;
+	private final MajorInterestRepository majorInterestRepository;
 	private final InterestRelationRepository interestRelationRepository;
 
 	public InterestNetworkResponse find(UUID accessorId) {
@@ -25,10 +29,19 @@ public class ReadInterestNetworkUseCase {
 		List<ReadInterestResponse> interests = interestRepository.findAllByRegistrantId(registrantId).stream()
 			.map(ReadInterestResponse::of)
 			.toList();
+		markMajorInterests(interests);
 
 		List<ReadInterestRelationResponse> relations = interestRelationRepository.findAllByRegistrantId(registrantId).stream()
 			.map(ReadInterestRelationResponse::of)
 			.toList();
 		return InterestNetworkResponse.of(interests, relations);
+	}
+
+	private void markMajorInterests(List<ReadInterestResponse> interestResponses) {
+		String interestIdsJson = JsonParser.toJson(interestResponses.stream().map(ReadInterestResponse::getId).toList());
+		List<Long> isMajorInterests = majorInterestRepository.existsAsMajorInterests(interestIdsJson);
+		IntStream.range(0, interestResponses.size())
+			.filter(i -> isMajorInterests.get(i) == 1)
+			.forEach(i -> interestResponses.get(i).updateMajorInterest());
 	}
 }

--- a/src/main/java/com/gomo/app/interest/application/ReadInterestUseCase.java
+++ b/src/main/java/com/gomo/app/interest/application/ReadInterestUseCase.java
@@ -3,13 +3,16 @@ package com.gomo.app.interest.application;
 import static com.gomo.app.common.exception.DomainErrorCode.*;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.gomo.app.common.application.ApplicationService;
 import com.gomo.app.common.exception.NotFoundException;
+import com.gomo.app.common.util.JsonParser;
 import com.gomo.app.interest.domain.model.Interest;
 import com.gomo.app.interest.domain.model.InterestId;
 import com.gomo.app.interest.domain.model.RegistrantId;
 import com.gomo.app.interest.domain.repository.InterestRepository;
+import com.gomo.app.interest.domain.repository.MajorInterestRepository;
 import com.gomo.app.interest.presentation.response.ListInterestResponse;
 import com.gomo.app.interest.presentation.response.ReadInterestResponse;
 
@@ -20,18 +23,33 @@ import lombok.RequiredArgsConstructor;
 public class ReadInterestUseCase {
 
 	private final InterestRepository interestRepository;
+	private final MajorInterestRepository majorInterestRepository;
 
 	public ReadInterestResponse find(InterestId interestId) {
 		Interest interest = interestRepository.findById(interestId)
 			.orElseThrow(() -> new NotFoundException(NOT_FOUND, "Interest not found with id: " + interestId.getId()));
 
-		return ReadInterestResponse.of(interest);
+		ReadInterestResponse response = ReadInterestResponse.of(interest);
+		if(majorInterestRepository.existsMajorInterestByInterestId(interestId)) {
+			response.updateMajorInterest();
+		}
+
+		return response;
 	}
 
 	public ListInterestResponse findAll(RegistrantId registrantId) {
-		List<ReadInterestResponse> list = interestRepository.findAllByRegistrantId(registrantId)
+		List<ReadInterestResponse> interestResponses = interestRepository.findAllByRegistrantId(registrantId)
 			.stream().map(ReadInterestResponse::of).toList();
+		markMajorInterests(interestResponses);
 
-		return ListInterestResponse.of(list);
+		return ListInterestResponse.of(interestResponses);
+	}
+
+	private void markMajorInterests(List<ReadInterestResponse> interests) {
+		String interestIdsJson = JsonParser.toJson(interests.stream().map(ReadInterestResponse::getId).toList());
+		List<Long> isMajorInterests = majorInterestRepository.existsAsMajorInterests(interestIdsJson);
+		IntStream.range(0, interests.size())
+			.filter(i -> isMajorInterests.get(i) == 1)
+			.forEach(i -> interests.get(i).updateMajorInterest());
 	}
 }

--- a/src/main/java/com/gomo/app/interest/domain/repository/MajorInterestRepository.java
+++ b/src/main/java/com/gomo/app/interest/domain/repository/MajorInterestRepository.java
@@ -18,9 +18,17 @@ public interface MajorInterestRepository extends JpaRepository<MajorInterest, Ma
 
 	@Query("select COALESCE(MAX(m.displayOrder.displayOrder), 0) from MajorInterest m " +
 		"where m.registrantId = :registrantId ")
-	int findMaxDisplayOrder(
-		@Param("registrantId") RegistrantId registrantId
-	);
+	int findMaxDisplayOrder(@Param("registrantId") RegistrantId registrantId);
+
+	boolean existsMajorInterestByInterestId(InterestId interestId);
+
+	@Query(value = """
+    SELECT EXISTS (
+        SELECT 1 FROM major_interest m WHERE m.interest_id = UNHEX(REPLACE(i.id, '-', ''))
+    )
+    FROM JSON_TABLE(:interestIds, '$[*]' COLUMNS (id CHAR(36) PATH '$')) AS i
+    """, nativeQuery = true)
+	List<Long> existsAsMajorInterests(@Param("interestIds") String interestIdsJson);
 
 	List<MajorInterest> findAllByRegistrantIdOrderByDisplayOrder(RegistrantId registrantId);
 

--- a/src/main/java/com/gomo/app/interest/presentation/response/ReadInterestResponse.java
+++ b/src/main/java/com/gomo/app/interest/presentation/response/ReadInterestResponse.java
@@ -17,6 +17,7 @@ public class ReadInterestResponse {
 	private int score;
 	private int scoreThreshold;
 	private int totalScore;
+	private boolean isMajorInterest;
 
 	private ReadInterestResponse(
 		UUID id,
@@ -48,5 +49,9 @@ public class ReadInterestResponse {
 			interest.getProficiency().getScore().getScore(),
 			interest.getProficiency().getLevel().getScoreThreshold(),
 			interest.getProficiency().getTotalScore());
+	}
+
+	public void updateMajorInterest() {
+		this.isMajorInterest = true;
 	}
 }

--- a/src/test/java/com/gomo/app/interest/documentation/snippet/InterestNetworkSnippet.java
+++ b/src/test/java/com/gomo/app/interest/documentation/snippet/InterestNetworkSnippet.java
@@ -1,15 +1,15 @@
 package com.gomo.app.interest.documentation.snippet;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.gomo.app.common.constant.ErrorResponseFields;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Snippet;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.gomo.app.common.constant.ErrorResponseFields;
 
 public class InterestNetworkSnippet {
 
@@ -28,6 +28,7 @@ public class InterestNetworkSnippet {
 		fieldWithPath("interests[].score").type(JsonFieldType.NUMBER).description("현재 점수"),
 		fieldWithPath("interests[].scoreThreshold").type(JsonFieldType.NUMBER).description("현재 레벨의 임계 점수"),
 		fieldWithPath("interests[].totalScore").type(JsonFieldType.NUMBER).description("전체 점수"),
+		fieldWithPath("interests[].majorInterest").type(JsonFieldType.BOOLEAN).description("주요 관심사 여부"),
 
 		fieldWithPath("relations").type(JsonFieldType.ARRAY).description("관심사 간의 연결 관계 목록"),
 		fieldWithPath("relations[].id").type(JsonFieldType.STRING).description("관심사 간선 아이디"),

--- a/src/test/java/com/gomo/app/interest/documentation/snippet/ListInterestSnippet.java
+++ b/src/test/java/com/gomo/app/interest/documentation/snippet/ListInterestSnippet.java
@@ -1,15 +1,15 @@
 package com.gomo.app.interest.documentation.snippet;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.gomo.app.common.constant.ErrorResponseFields;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Snippet;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.gomo.app.common.constant.ErrorResponseFields;
 
 public class ListInterestSnippet {
 
@@ -27,7 +27,8 @@ public class ListInterestSnippet {
 		fieldWithPath("interests[].level").type(JsonFieldType.NUMBER).description("레벨"),
 		fieldWithPath("interests[].score").type(JsonFieldType.NUMBER).description("현재 점수"),
 		fieldWithPath("interests[].scoreThreshold").type(JsonFieldType.NUMBER).description("현재 레벨의 임계 점수"),
-		fieldWithPath("interests[].totalScore").type(JsonFieldType.NUMBER).description("전체 점수")
+		fieldWithPath("interests[].totalScore").type(JsonFieldType.NUMBER).description("전체 점수"),
+		fieldWithPath("interests[].majorInterest").type(JsonFieldType.BOOLEAN).description("주요 관심사 여부")
 	);
 
 	public static RestDocumentationFilter create() {

--- a/src/test/java/com/gomo/app/interest/documentation/snippet/ReadInterestSnippet.java
+++ b/src/test/java/com/gomo/app/interest/documentation/snippet/ReadInterestSnippet.java
@@ -1,15 +1,15 @@
 package com.gomo.app.interest.documentation.snippet;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.gomo.app.common.constant.ErrorResponseFields;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Snippet;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.gomo.app.common.constant.ErrorResponseFields;
 
 public class ReadInterestSnippet {
 
@@ -26,7 +26,8 @@ public class ReadInterestSnippet {
 		fieldWithPath("level").type(JsonFieldType.NUMBER).description("레벨"),
 		fieldWithPath("score").type(JsonFieldType.NUMBER).description("현재 점수"),
 		fieldWithPath("scoreThreshold").type(JsonFieldType.NUMBER).description("현재 레벨의 임계 점수"),
-		fieldWithPath("totalScore").type(JsonFieldType.NUMBER).description("전체 점수")
+		fieldWithPath("totalScore").type(JsonFieldType.NUMBER).description("전체 점수"),
+		fieldWithPath("majorInterest").type(JsonFieldType.BOOLEAN).description("주요 관심사 여부")
 	);
 
 	public static RestDocumentationFilter create() {

--- a/src/test/java/com/gomo/app/interest/integration/MajorInterestRepositoryTest.java
+++ b/src/test/java/com/gomo/app/interest/integration/MajorInterestRepositoryTest.java
@@ -3,14 +3,19 @@ package com.gomo.app.interest.integration;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gomo.app.common.IntegrationTestBase;
+import com.gomo.app.interest.common.dataprovider.InterestDataProvider;
 import com.gomo.app.interest.common.dataprovider.MajorInterestDataProvider;
+import com.gomo.app.interest.domain.model.Interest;
 import com.gomo.app.interest.domain.model.MajorInterest;
 import com.gomo.app.interest.domain.model.RegistrantId;
 import com.gomo.app.interest.domain.repository.MajorInterestRepository;
@@ -26,8 +31,13 @@ public class MajorInterestRepositoryTest extends IntegrationTestBase {
 	private MajorInterest java;
 	private MajorInterest spring;
 
+	@Autowired
+	private InterestDataProvider interestDataProvider;
+	private Interest backend;
+
 	@BeforeEach
 	public void setUp() {
+		backend = interestDataProvider.backend();
 		java = majorInterestDataProvider.java();
 		spring = majorInterestDataProvider.spring();
 	}
@@ -50,5 +60,17 @@ public class MajorInterestRepositoryTest extends IntegrationTestBase {
 		long actual = sut.findMaxDisplayOrder(RegistrantId.of(java.getRegistrantId().getId()));
 
 		assertThat(actual).isEqualTo(2);
+	}
+
+	@DisplayName("관심사가 아이디 목록으로 주요 관심사가 등록되어 있는지 확인한다.")
+	@Test
+	void exist_major_interests() throws JsonProcessingException {
+		List<UUID> interestIds = List.of(backend.getId().getId(), java.getInterestId().getId(), spring.getInterestId().getId());
+		String interestIdsJson = new ObjectMapper().writeValueAsString(interestIds);
+		List<Long> isMajorInterests = sut.existsAsMajorInterests(interestIdsJson);
+
+		assertThat(isMajorInterests.get(0)).isEqualTo(0);
+		assertThat(isMajorInterests.get(1)).isEqualTo(1);
+		assertThat(isMajorInterests.get(2)).isEqualTo(1);
 	}
 }

--- a/src/test/java/com/gomo/app/interest/unit/usecase/ReadInterestNetworkUseCaseTest.java
+++ b/src/test/java/com/gomo/app/interest/unit/usecase/ReadInterestNetworkUseCaseTest.java
@@ -22,6 +22,7 @@ import com.gomo.app.interest.domain.model.InterestRelation;
 import com.gomo.app.interest.domain.model.RegistrantId;
 import com.gomo.app.interest.domain.repository.InterestRelationRepository;
 import com.gomo.app.interest.domain.repository.InterestRepository;
+import com.gomo.app.interest.domain.repository.MajorInterestRepository;
 import com.gomo.app.interest.presentation.response.InterestNetworkResponse;
 
 @DisplayName("[Application unit]: 관심사 네트워크 조회 테스트")
@@ -35,6 +36,9 @@ public class ReadInterestNetworkUseCaseTest {
 	private InterestRepository interestRepository;
 
 	@Mock
+	private MajorInterestRepository majorInterestRepository;
+
+	@Mock
 	private InterestRelationRepository interestRelationRepository;
 
 	@DisplayName("관심사 네트워크를 조회한다.")
@@ -42,7 +46,10 @@ public class ReadInterestNetworkUseCaseTest {
 	void find_interest_network() {
 		Interest interest1 = InterestFixture.interest();
 		Interest interest2 = InterestFixture.interest();
+		long isNotMajorInterest = 0L;
+		long isMajorInterest = 1L;
 		doReturn(List.of(interest1, interest2)).when(interestRepository).findAllByRegistrantId(any(RegistrantId.class));
+		doReturn(List.of(isNotMajorInterest, isMajorInterest)).when(majorInterestRepository).existsAsMajorInterests(anyString());
 
 		InterestRelation relation = InterestRelationFixture.relation();
 		doReturn(List.of(relation)).when(interestRelationRepository).findAllByRegistrantId(any(RegistrantId.class));
@@ -51,8 +58,8 @@ public class ReadInterestNetworkUseCaseTest {
 
 		assertThat(actual.getInterests())
 			.hasSize(2)
-			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore")
-			.containsExactly(createInterestTuple(interest1), createInterestTuple(interest2));
+			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore", "isMajorInterest")
+			.containsExactly(createInterestTuple(interest1, isNotMajorInterest), createInterestTuple(interest2, isMajorInterest));
 
 		assertThat(actual.getRelations())
 			.hasSize(1)
@@ -65,7 +72,7 @@ public class ReadInterestNetworkUseCaseTest {
 			relation.getChildInterestId().getId());
 	}
 
-	private static @NotNull Tuple createInterestTuple(Interest interest) {
+	private static @NotNull Tuple createInterestTuple(Interest interest, long isMajorInterest) {
 		return tuple(
 			interest.getId().getId(),
 			interest.getRegistrantId().getId(),
@@ -73,7 +80,8 @@ public class ReadInterestNetworkUseCaseTest {
 			interest.getLogoUrl(),
 			interest.getProficiency().getLevel().getLevel(),
 			interest.getProficiency().getScore().getScore(),
-			interest.getProficiency().getTotalScore()
+			interest.getProficiency().getTotalScore(),
+			isMajorInterest != 0
 		);
 	}
 }

--- a/src/test/java/com/gomo/app/interest/unit/usecase/ReadInterestUseCaseTest.java
+++ b/src/test/java/com/gomo/app/interest/unit/usecase/ReadInterestUseCaseTest.java
@@ -21,6 +21,7 @@ import com.gomo.app.interest.domain.model.Interest;
 import com.gomo.app.interest.domain.model.InterestId;
 import com.gomo.app.interest.domain.model.RegistrantId;
 import com.gomo.app.interest.domain.repository.InterestRepository;
+import com.gomo.app.interest.domain.repository.MajorInterestRepository;
 import com.gomo.app.interest.presentation.response.ListInterestResponse;
 import com.gomo.app.interest.presentation.response.ReadInterestResponse;
 
@@ -34,16 +35,20 @@ public class ReadInterestUseCaseTest {
 	@Mock
 	private InterestRepository interestRepository;
 
+	@Mock
+	private MajorInterestRepository majorInterestRepository;
+
 	@DisplayName("관심사를 하나 조회한다.")
 	@Test
 	void find_interest() {
 		Interest expected = InterestFixture.interest();
 		doReturn(Optional.of(expected)).when(interestRepository).findById(any(InterestId.class));
+		doReturn(false).when(majorInterestRepository).existsMajorInterestByInterestId(any(InterestId.class));
 
 		ReadInterestResponse actual = sut.find(expected.getId());
 
 		assertThat(actual)
-			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore")
+			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore", "isMajorInterest")
 			.containsExactly(
 				expected.getId().getId(),
 				expected.getRegistrantId().getId(),
@@ -51,7 +56,8 @@ public class ReadInterestUseCaseTest {
 				expected.getLogoUrl(),
 				expected.getProficiency().getLevel().getLevel(),
 				expected.getProficiency().getScore().getScore(),
-				expected.getProficiency().getTotalScore()
+				expected.getProficiency().getTotalScore(),
+				false
 			);
 	}
 
@@ -60,17 +66,20 @@ public class ReadInterestUseCaseTest {
 	void find_interest_list() {
 		Interest expected1 = InterestFixture.interest();
 		Interest expected2 = InterestFixture.interest();
+		long isNotMajorInterest = 0L;
+		long isMajorInterest = 1L;
 		doReturn(List.of(expected1, expected2)).when(interestRepository).findAllByRegistrantId(any(RegistrantId.class));
+		doReturn(List.of(isNotMajorInterest, isMajorInterest)).when(majorInterestRepository).existsAsMajorInterests(anyString());
 
 		ListInterestResponse actual = sut.findAll(RegistrantId.of(expected1.getRegistrantId().getId()));
 
 		assertThat(actual.getInterests())
 			.hasSize(2)
-			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore")
-			.containsExactly(createTuple(expected1), createTuple(expected2));
+			.extracting("id", "registrantId", "name", "logoUrl", "level", "score", "totalScore", "isMajorInterest")
+			.containsExactly(createTuple(expected1, isNotMajorInterest), createTuple(expected2, isMajorInterest));
 	}
 
-	private static @NotNull Tuple createTuple(Interest interest) {
+	private static @NotNull Tuple createTuple(Interest interest, long isMajorInterest) {
 		return tuple(
 			interest.getId().getId(),
 			interest.getRegistrantId().getId(),
@@ -78,7 +87,8 @@ public class ReadInterestUseCaseTest {
 			interest.getLogoUrl(),
 			interest.getProficiency().getLevel().getLevel(),
 			interest.getProficiency().getScore().getScore(),
-			interest.getProficiency().getTotalScore()
+			interest.getProficiency().getTotalScore(),
+			isMajorInterest != 0
 		);
 	}
 }


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** [#GOMO-110](https://kkj1250.atlassian.net/jira/software/projects/GOMO/boards/2/timeline?selectedIssue=GOMO-110)

<br>

### 내용

- [X] 관심사 단건, 목록, 네트워크 조회 시, **주요 관심사 여부도 함께 반환**합니다.
- [X] 응답 객체 필드 추가로 인해 테스트를 수정했습니다.