### PR TITLE
[GOMO-111] 주요 관심사 조회 스펙 변경

### DIFF
--- a/src/main/java/com/gomo/app/interest/presentation/response/ReadMajorInterestResponse.java
+++ b/src/main/java/com/gomo/app/interest/presentation/response/ReadMajorInterestResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class ReadMajorInterestResponse {
 
 	private UUID id;
+	private UUID interestId;
 	private String name;
 	private String logoUrl;
 	private int level;
@@ -20,6 +21,7 @@ public class ReadMajorInterestResponse {
 
 	private ReadMajorInterestResponse(
 		UUID id,
+		UUID interestId,
 		String name,
 		String logoUrl,
 		int level,
@@ -28,6 +30,7 @@ public class ReadMajorInterestResponse {
 		int displayOrder
 	) {
 		this.id = id;
+		this.interestId = interestId;
 		this.name = name;
 		this.logoUrl = logoUrl;
 		this.level = level;
@@ -39,6 +42,7 @@ public class ReadMajorInterestResponse {
 	public static ReadMajorInterestResponse of(MajorInterest majorInterest, Interest interest) {
 		return new ReadMajorInterestResponse(
 			majorInterest.getId().getId(),
+			interest.getId().getId(),
 			interest.getName().toString(),
 			interest.getLogoUrl(),
 			interest.getProficiency().getLevel().getLevel(),

--- a/src/test/java/com/gomo/app/interest/documentation/snippet/ListMajorInterestSnippet.java
+++ b/src/test/java/com/gomo/app/interest/documentation/snippet/ListMajorInterestSnippet.java
@@ -1,15 +1,15 @@
 package com.gomo.app.interest.documentation.snippet;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.gomo.app.common.constant.ErrorResponseFields;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Snippet;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.gomo.app.common.constant.ErrorResponseFields;
 
 public class ListMajorInterestSnippet {
 
@@ -21,6 +21,7 @@ public class ListMajorInterestSnippet {
 	private static final Snippet RESPONSE_FIELDS = responseFields(
 		fieldWithPath("majorInterests").type(JsonFieldType.ARRAY).description("주요 관심사 목록"),
 		fieldWithPath("majorInterests[].id").type(JsonFieldType.STRING).description("주요 관심사 아이디"),
+		fieldWithPath("majorInterests[].interestId").type(JsonFieldType.STRING).description("관심사 아이디"),
 		fieldWithPath("majorInterests[].name").type(JsonFieldType.STRING).description("관심사 이름"),
 		fieldWithPath("majorInterests[].logoUrl").type(JsonFieldType.STRING).description("관심사 로고 이미지"),
 		fieldWithPath("majorInterests[].level").type(JsonFieldType.NUMBER).description("레벨"),

--- a/src/test/java/com/gomo/app/interest/unit/usecase/ReadMajorInterestUseCaseTest.java
+++ b/src/test/java/com/gomo/app/interest/unit/usecase/ReadMajorInterestUseCaseTest.java
@@ -48,10 +48,10 @@ public class ReadMajorInterestUseCaseTest {
 
 		assertThat(response.getMajorInterests())
 			.hasSize(2)
-			.extracting("id", "name")
+			.extracting("id", "interestId", "name")
 			.containsExactly(
-				tuple(expected1.getId().getId(), "interest1"),
-				tuple(expected2.getId().getId(), "interest2")
+				tuple(expected1.getId().getId(), expected1.getInterestId().getId(), "interest1"),
+				tuple(expected2.getId().getId(), expected2.getInterestId().getId(), "interest2")
 			);
 	}
 


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** [#GOMO-111](https://kkj1250.atlassian.net/jira/software/projects/GOMO/boards/2/timeline?selectedIssue=GOMO-111)

<br>

### 내용

- [X] 주요 관심사 조회 시, 관심사 아이디도 함께 반환하도록 수정했습니다.
- [X] 응답 객체 수정으로 인해 테스트 코드를 수정했습니다.