### PR TITLE
[GOMO-103] OAuth 리팩토링 및 Provider 추가

### DIFF
--- a/src/main/java/com/gomo/app/member/application/OAuthUseCase.java
+++ b/src/main/java/com/gomo/app/member/application/OAuthUseCase.java
@@ -9,6 +9,8 @@ import com.gomo.app.member.domain.repository.MemberRepository;
 import com.gomo.app.member.exception.MemberErrorCode;
 import com.gomo.app.member.exception.MemberPolicyViolationException;
 import com.gomo.app.member.infrastructure.JwtSessionRedisService;
+import com.gomo.app.member.infrastructure.oauth.OAuthProvider;
+import com.gomo.app.member.infrastructure.oauth.OAuthProviderFactory;
 import com.gomo.app.member.presentation.response.CreateMemberResponse;
 import com.gomo.app.member.presentation.response.LoginMemberResponse;
 import jakarta.transaction.Transactional;
@@ -25,33 +27,18 @@ import java.util.UUID;
 @ApplicationService
 public class OAuthUseCase {
 
-    private final RestClient restClient;
+    private final OAuthProviderFactory providerFactory;
     private final MemberRepository memberRepository;
     private final JwtSessionRedisService jwtSessionRedisService;
     private final JwtUtil jwtUtil;
 
-    @Value("${oauth.google.client-id}")
-    private String clientId;
-
-    @Value("${oauth.google.client-secret}")
-    private String clientSecret;
-
-    @Value("${oauth.google.redirect-uri}")
-    private String redirectUri;
-
-    @Value("${oauth.google.token-uri}")
-    private String tokenUri;
-
-    @Value("${oauth.google.user-info-uri}")
-    private String userInfoUri;
-
     @Transactional
-    public LoginMemberResponse login(String code){
-        String googleAccessToken = getAccessToken(code);
-        JsonNode userInfo = getUserResource(googleAccessToken);
+    public LoginMemberResponse login(String providerName, String code){
+        OAuthProvider provider = providerFactory.getProvider(providerName);
+        OAuthUserInfo userInfo = provider.authenticate(code);
 
-        Member member = memberRepository.findByEmail(Email.of(userInfo.get("email").asText()))
-                .orElseGet(() -> createMember(userInfo, code));
+        Member member = memberRepository.findByEmail(Email.of(userInfo.getEmail()))
+                .orElseGet(() -> createMember(userInfo, providerName));
 
         switch(member.getActivateStatus()){
 			case DELETED -> throw new MemberPolicyViolationException(MemberErrorCode.MEMBER_DELETED, "member info has been deleted. check email or password");
@@ -69,36 +56,17 @@ public class OAuthUseCase {
 		return LoginMemberResponse.of(member.getId(), accessToken, refreshToken, refreshTokenExptime);
     }
 
-    private Member createMember(JsonNode userInfo, String code){
+    private Member createMember(OAuthUserInfo userInfo, String providerName){
         UUID uuid = UUIDGenerator.generate();
         MemberId memberId = MemberId.of(uuid);
-        String email = userInfo.get("email").asText();
-        String name = userInfo.get("name").asText();
-        Member member = Member.of(memberId, Email.of(email), null, null, MemberName.of(name), null, LoginProvider.GOOGLE);
+        Member member = Member.of(
+                memberId,
+                Email.of(userInfo.getEmail()),
+                null,
+                null,
+                MemberName.of(userInfo.getName()),
+                null,
+                LoginProvider.valueOf(providerName.toUpperCase()));
         return memberRepository.save(member);
-    }
-
-    private String getAccessToken(String code){
-        ResponseEntity<JsonNode> response = restClient.post()
-                .uri(tokenUri)
-                .body(Map.of(
-                        "code", code,
-                        "client_id", clientId,
-                        "client_secret", clientSecret,
-                        "redirect_uri", redirectUri,
-                        "grant_type", "authorization_code"
-                )).retrieve()
-                .toEntity(JsonNode.class);
-        JsonNode accessToken = response.getBody();
-        return accessToken.get("access_token").asText();
-    }
-
-    private JsonNode getUserResource(String accessToken){
-        ResponseEntity<JsonNode> response = restClient.get()
-                .uri(userInfoUri)
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .toEntity(JsonNode.class);
-        return response.getBody();
     }
 }

--- a/src/main/java/com/gomo/app/member/domain/model/LoginProvider.java
+++ b/src/main/java/com/gomo/app/member/domain/model/LoginProvider.java
@@ -1,5 +1,5 @@
 package com.gomo.app.member.domain.model;
 
 public enum LoginProvider {
-    EMAIL, GOOGLE
+    EMAIL, GOOGLE, KAKAO, NAVER
 }

--- a/src/main/java/com/gomo/app/member/domain/model/OAuthUserInfo.java
+++ b/src/main/java/com/gomo/app/member/domain/model/OAuthUserInfo.java
@@ -1,0 +1,12 @@
+package com.gomo.app.member.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuthUserInfo {
+    private String providerId;
+    private String email;
+    private String name;
+}

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/OAuthProvider.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/OAuthProvider.java
@@ -1,0 +1,7 @@
+package com.gomo.app.member.infrastructure.oauth;
+
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+
+public interface OAuthProvider {
+    OAuthUserInfo authenticate(String code);
+}

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/OAuthProviderFactory.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/OAuthProviderFactory.java
@@ -1,0 +1,21 @@
+package com.gomo.app.member.infrastructure.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthProviderFactory {
+
+    private final Map<String, OAuthProvider> providers;
+
+    public OAuthProvider getProvider(String providerName){
+        OAuthProvider provider = providers.get(providerName);
+        if(provider == null){
+            throw new IllegalArgumentException("Unsupported OAuth Provider: " + providerName);
+        }
+        return provider;
+    }
+}

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/GoogleOAuthProvider.java
@@ -1,0 +1,69 @@
+package com.gomo.app.member.infrastructure.oauth.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+import com.gomo.app.member.infrastructure.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Component("google")
+@RequiredArgsConstructor
+public class GoogleOAuthProvider implements OAuthProvider {
+    private final RestClient restClient;
+
+    @Value("${oauth.google.client-id}")
+    private String clientId;
+
+    @Value("${oauth.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${oauth.google.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.google.user-info-uri}")
+    private String userInfoUri;
+
+    @Override
+    public OAuthUserInfo authenticate(String code) {
+        String accessToken = getAccessToken(code);
+        JsonNode userInfo = getUserResource(accessToken);
+
+        return OAuthUserInfo.builder()
+                .email(userInfo.get("email").asText())
+                .name(userInfo.get("name").asText())
+                .providerId(userInfo.get("sub").asText())
+                .build();
+    }
+
+    private String getAccessToken(String code){
+        ResponseEntity<JsonNode> response = restClient.post()
+                .uri(tokenUri)
+                .body(Map.of(
+                        "code", code,
+                        "client_id", clientId,
+                        "client_secret", clientSecret,
+                        "redirect_uri", redirectUri,
+                        "grant_type", "authorization_code"
+                )).retrieve()
+                .toEntity(JsonNode.class);
+        JsonNode accessToken = response.getBody();
+        return accessToken.get("access_token").asText();
+    }
+
+    private JsonNode getUserResource(String accessToken){
+        ResponseEntity<JsonNode> response = restClient.get()
+                .uri(userInfoUri)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(JsonNode.class);
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/GoogleOAuthProvider.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/GoogleOAuthProvider.java
@@ -39,7 +39,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
         return OAuthUserInfo.builder()
                 .email(userInfo.get("email").asText())
                 .name(userInfo.get("name").asText())
-                .providerId(userInfo.get("sub").asText())
+                .providerId("google")
                 .build();
     }
 

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/KakaoOAuthProvider.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/KakaoOAuthProvider.java
@@ -1,0 +1,75 @@
+package com.gomo.app.member.infrastructure.oauth.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+import com.gomo.app.member.infrastructure.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component("kakao")
+@RequiredArgsConstructor
+public class KakaoOAuthProvider implements OAuthProvider {
+
+    private final RestClient restClient;
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${oauth.kakao.token-uri}")
+    private String kakaoTokenUri;
+
+    @Value("${oauth.kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    @Override
+    public OAuthUserInfo authenticate(String code) {
+        String accessToken = getAccessToken(code);
+        JsonNode userInfo = getResources(accessToken);
+
+        return OAuthUserInfo.builder()
+                .email(userInfo.get("email").asText())
+                .name(userInfo.get("profile").get("nickname").asText())
+                .providerId("kakao")
+                .build();
+    }
+
+    private String getAccessToken(String code){
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("client_id", kakaoClientId);
+        body.add("redirect_uri", kakaoRedirectUri);
+
+        ResponseEntity<JsonNode> resposne = restClient.post()
+                .uri(kakaoTokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .body(body)
+                .retrieve().toEntity(JsonNode.class);
+        JsonNode accessToken = resposne.getBody();
+        return accessToken.get("access_token").asText();
+    }
+
+    private JsonNode getResources(String accessToken){
+        ResponseEntity<JsonNode> response = restClient.get()
+                .uri(kakaoUserInfoUri)
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8")
+                .header(HttpHeaders.AUTHORIZATION,"Bearer "+accessToken)
+                .retrieve().toEntity(JsonNode.class);
+        return response.getBody().get("kakao_account");
+    }
+}

--- a/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/NaverOAuthProvider.java
+++ b/src/main/java/com/gomo/app/member/infrastructure/oauth/provider/NaverOAuthProvider.java
@@ -1,0 +1,76 @@
+package com.gomo.app.member.infrastructure.oauth.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+import com.gomo.app.member.infrastructure.oauth.OAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component("naver")
+@RequiredArgsConstructor
+public class NaverOAuthProvider implements OAuthProvider {
+
+    private final RestClient restClient;
+
+    @Value("${oauth.naver.client-id}")
+    private String clientId;
+
+    @Value("${oauth.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.naver.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${oauth.naver.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.naver.user-info-uri}")
+    private String userInfoUri;
+
+    @Override
+    public OAuthUserInfo authenticate(String code) {
+        String accessToken = getAccessToken(code);
+        JsonNode userInfo = getResources(accessToken);
+
+        return OAuthUserInfo.builder()
+                .email(userInfo.get("email").asText())
+                .name(userInfo.get("name").asText())
+                .providerId("naver")
+                .build();
+    }
+
+    private String getAccessToken(String code){
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("code", code);
+
+        ResponseEntity<JsonNode> response = restClient.post()
+                .uri(tokenUri)
+                .body(body)
+                .retrieve().toEntity(JsonNode.class);
+        JsonNode accessToken = response.getBody();
+        return accessToken.get("access_token").asText();
+    }
+
+    private JsonNode getResources(String accessToken){
+        ResponseEntity<JsonNode> response = restClient.get()
+                .uri(userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve().toEntity(JsonNode.class);
+
+        return response.getBody().get("response");
+    }
+}

--- a/src/main/java/com/gomo/app/member/presentation/LoginMemberApi.java
+++ b/src/main/java/com/gomo/app/member/presentation/LoginMemberApi.java
@@ -62,7 +62,7 @@ public class LoginMemberApi {
 				.httpOnly(true)
 				.secure(true)
 				.path("/members/refresh")
-				.maxAge(Duration.ofSeconds(expiry))
+				.maxAge(Duration.ofMillis(expiry))
 				.build();
 	}
 

--- a/src/main/java/com/gomo/app/member/presentation/OauthApi.java
+++ b/src/main/java/com/gomo/app/member/presentation/OauthApi.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -21,9 +22,9 @@ public class OauthApi {
 
     private final OAuthUseCase oAuthUseCase;
 
-    @GetMapping("/google")
-    public ResponseEntity<TokenResponse> googleLogin(@RequestParam String code){
-        LoginMemberResponse tokens = oAuthUseCase.login(code);
+    @GetMapping("/{provider}")
+    public ResponseEntity<TokenResponse> oauthLogin(@PathVariable String provider, @RequestParam String code){
+        LoginMemberResponse tokens = oAuthUseCase.login(provider, code);
         ResponseCookie cookie = createRefreshTokenCookie(tokens.getRefreshToken(), tokens.getExpiresIn());
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -35,7 +36,7 @@ public class OauthApi {
 				.httpOnly(true)
 				.secure(true)
 				.path("/members/refresh")
-				.maxAge(Duration.ofSeconds(expiry))
+				.maxAge(Duration.ofMillis(expiry))
 				.build();
 	}
 }

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE member (
     daily_quest_threshold TINYINT,
     weekly_quest_threshold TINYINT,
     monthly_quest_threshold TINYINT,
-    login_provider ENUM('EMAIL', 'GOOGLE'),
+    login_provider ENUM('EMAIL', 'GOOGLE', 'KAKAO', 'NAVER'),
     role_type ENUM('ROLE_MEMBER', 'ROLE_ADMIN'),
     subscription_plan ENUM('FREE', 'BASIC', 'PREMIUM'),
     activate_status ENUM('ACTIVE', 'INACTIVE', 'BLOCKED', 'DELETED'),

--- a/src/test/java/com/gomo/app/member/documentation/OAuthDocuementationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/OAuthDocuementationTest.java
@@ -45,7 +45,7 @@ public class OAuthDocuementationTest extends DocumentationTestBase {
                 expectedRefreshToken,
                 expiresIn
         );
-        doReturn(expected).when(oAuthUseCase).login(anyString());
+        doReturn(expected).when(oAuthUseCase).login(anyString(), anyString());
 
         given(this.specification).filter(filter)
                 .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)

--- a/src/test/java/com/gomo/app/member/unit/usecase/OAuthUseCaseTest.java
+++ b/src/test/java/com/gomo/app/member/unit/usecase/OAuthUseCaseTest.java
@@ -6,14 +6,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.gomo.app.common.util.JwtUtil;
 import com.gomo.app.member.application.OAuthUseCase;
 import com.gomo.app.member.common.fixture.MemberFixture;
-import com.gomo.app.member.domain.model.ActivateStatus;
-import com.gomo.app.member.domain.model.Email;
-import com.gomo.app.member.domain.model.Member;
-import com.gomo.app.member.domain.model.MemberId;
+import com.gomo.app.member.domain.model.*;
 import com.gomo.app.member.domain.repository.MemberRepository;
 import com.gomo.app.member.domain.service.PasswordService;
 import com.gomo.app.member.exception.MemberPolicyViolationException;
 import com.gomo.app.member.infrastructure.JwtSessionRedisService;
+import com.gomo.app.member.infrastructure.oauth.OAuthProvider;
+import com.gomo.app.member.infrastructure.oauth.OAuthProviderFactory;
 import com.gomo.app.member.presentation.response.LoginMemberResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,9 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Optional;
 
@@ -46,6 +42,12 @@ public class OAuthUseCaseTest {
     OAuthUseCase sut;
 
     @Mock
+    OAuthProviderFactory providerFactory;
+
+    @Mock
+    OAuthProvider oAuthProvider;
+
+    @Mock
     MemberRepository memberRepository;
 
     @Mock
@@ -58,44 +60,30 @@ public class OAuthUseCaseTest {
     private PasswordService passwordService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final String GOOGLE_AUTH_CODE = "google_auth_code";
+    private final String GOOGLE_PROVIDER = "GOOGLE";
+    private final String OAUTH_CODE = "google_auth_code";
     private final String EMAIL = "test@google.com";
     private final String NAME = "testname";
     private final String JWT_ACCESS_TOKEN = "jwt_access_token";
     private final String JWT_REFRESH_TOKEN = "jwt_refresh_token";
     private final long REFRESH_TOKEN_EXPIRATION_TIME = 2592000000L;
 
-    private RestTemplate restTemplate;
-    private RestClient restClient;
-    private MockRestServiceServer mockServer;
-
     @BeforeEach
     void setUp(){
-        restTemplate = new RestTemplate();
-        mockServer = MockRestServiceServer.createServer(restTemplate);
 
-        restClient= RestClient.builder(restTemplate).build();
+        doReturn(oAuthProvider).when(providerFactory).getProvider(GOOGLE_PROVIDER);
 
-        ReflectionTestUtils.setField(sut, "restClient", restClient);
-
-        ReflectionTestUtils.setField(sut, "clientId", "test-clint-id");
-        ReflectionTestUtils.setField(sut, "clientSecret", "test-clint-secret");
-        ReflectionTestUtils.setField(sut, "redirectUri", "http://test-redirect-uri");
-        ReflectionTestUtils.setField(sut, "tokenUri", "http://test-accessToken-uri");
-        ReflectionTestUtils.setField(sut, "userInfoUri", "http://test-user-info-uri");
+        doReturn(OAuthUserInfo.builder()
+                .email(EMAIL)
+                .name(NAME)
+                .providerId("google-provider-id")
+                .build()
+        ).when(oAuthProvider).authenticate(OAUTH_CODE);
     }
 
     @DisplayName("OAuth를 이용하여 회원가입에 성공한다.")
     @Test
     public void signup_with_oauth(){
-        mockServer.expect(requestTo("http://test-accessToken-uri"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(createAccessTokenNode().toString(), MediaType.APPLICATION_JSON));
-
-        mockServer.expect(requestTo("http://test-user-info-uri"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(createUserInfoNode().toString(), MediaType.APPLICATION_JSON));
-
         doReturn(Optional.empty()).when(memberRepository).findByEmail(any(Email.class));
 
         Member member = MemberFixture.member(passwordService);
@@ -105,7 +93,7 @@ public class OAuthUseCaseTest {
         doReturn(JWT_REFRESH_TOKEN).when(jwtUtil).generateRefreshToken(any(MemberId.class));
         doReturn(REFRESH_TOKEN_EXPIRATION_TIME).when(jwtUtil).extractExpirationTime(JWT_REFRESH_TOKEN);
 
-        LoginMemberResponse actual = sut.login(GOOGLE_AUTH_CODE);
+        LoginMemberResponse actual = sut.login(GOOGLE_PROVIDER, OAUTH_CODE);
 
         assertThat(actual.getAccessToken()).isEqualTo(JWT_ACCESS_TOKEN);
         assertThat(actual.getRefreshToken()).isEqualTo(JWT_REFRESH_TOKEN);
@@ -115,14 +103,6 @@ public class OAuthUseCaseTest {
     @DisplayName("OAuth를 이용하여 회원가입 및 로그인에 성공한다.")
     @Test
     public void login_with_oauth(){
-        mockServer.expect(requestTo("http://test-accessToken-uri"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(createAccessTokenNode().toString(), MediaType.APPLICATION_JSON));
-
-        mockServer.expect(requestTo("http://test-user-info-uri"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(createUserInfoNode().toString(), MediaType.APPLICATION_JSON));
-
         Member member = MemberFixture.member(passwordService);
         doReturn(Optional.of(member)).when(memberRepository).findByEmail(any(Email.class));
 
@@ -130,7 +110,7 @@ public class OAuthUseCaseTest {
         doReturn(JWT_REFRESH_TOKEN).when(jwtUtil).generateRefreshToken(any(MemberId.class));
         doReturn(REFRESH_TOKEN_EXPIRATION_TIME).when(jwtUtil).extractExpirationTime(JWT_REFRESH_TOKEN);
 
-        LoginMemberResponse actual = sut.login(GOOGLE_AUTH_CODE);
+        LoginMemberResponse actual = sut.login(GOOGLE_PROVIDER, OAUTH_CODE);
 
         assertThat(actual.getAccessToken()).isEqualTo(JWT_ACCESS_TOKEN);
         assertThat(actual.getRefreshToken()).isEqualTo(JWT_REFRESH_TOKEN);
@@ -140,18 +120,10 @@ public class OAuthUseCaseTest {
     @DisplayName("Block 된 이메일로 OAuth로그인을 시도할 경우, 실패한다.")
     @Test
     public void oauth_login_with_blocked_email(){
-        mockServer.expect(requestTo("http://test-accessToken-uri"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(createAccessTokenNode().toString(), MediaType.APPLICATION_JSON));
-
-        mockServer.expect(requestTo("http://test-user-info-uri"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(createUserInfoNode().toString(), MediaType.APPLICATION_JSON));
-
         Member member = MemberFixture.member(ActivateStatus.BLOCKED, passwordService);
         doReturn(Optional.of(member)).when(memberRepository).findByEmail(any(Email.class));
 
-        assertThatThrownBy(() -> sut.login(GOOGLE_AUTH_CODE))
+        assertThatThrownBy(() -> sut.login(GOOGLE_PROVIDER, OAUTH_CODE))
                 .isInstanceOf(MemberPolicyViolationException.class)
                 .hasMessageContaining("member info has been blocked. check email or password");
     }
@@ -159,32 +131,11 @@ public class OAuthUseCaseTest {
     @DisplayName("탈퇴처리된 이메일로 OAuth로그인을 시도할 경우, 실패한다.")
     @Test
     public void oauth_login_with_deleted_email(){
-        mockServer.expect(requestTo("http://test-accessToken-uri"))
-                .andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess(createAccessTokenNode().toString(), MediaType.APPLICATION_JSON));
-
-        mockServer.expect(requestTo("http://test-user-info-uri"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(createUserInfoNode().toString(), MediaType.APPLICATION_JSON));
-
         Member member = MemberFixture.member(ActivateStatus.DELETED, passwordService);
         doReturn(Optional.of(member)).when(memberRepository).findByEmail(any(Email.class));
 
-        assertThatThrownBy(() -> sut.login(GOOGLE_AUTH_CODE))
+        assertThatThrownBy(() -> sut.login(GOOGLE_PROVIDER, OAUTH_CODE))
                 .isInstanceOf(MemberPolicyViolationException.class)
                 .hasMessageContaining("member info has been deleted. check email or password");
-    }
-
-    private JsonNode createAccessTokenNode(){
-        ObjectNode node = objectMapper.createObjectNode();
-        node.put("access_token", GOOGLE_AUTH_CODE);
-        return node;
-    }
-
-    private JsonNode createUserInfoNode(){
-        ObjectNode node = objectMapper.createObjectNode();
-        node.put("email", EMAIL);
-        node.put("name", NAME);
-        return node;
     }
 }

--- a/src/test/resources/database/test-schema.sql
+++ b/src/test/resources/database/test-schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE member (
     daily_quest_threshold TINYINT,
     weekly_quest_threshold TINYINT,
     monthly_quest_threshold TINYINT,
-    login_provider ENUM('EMAIL', 'GOOGLE'),
+    login_provider ENUM('EMAIL', 'GOOGLE', 'KAKAO', 'NAVER'),
     role_type ENUM('ROLE_MEMBER', 'ROLE_ADMIN'),
     subscription_plan ENUM('FREE', 'BASIC', 'PREMIUM'),
     activate_status ENUM('ACTIVE', 'INACTIVE', 'BLOCKED', 'DELETED'),


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** #[GOMO-103](https://kkj1250.atlassian.net/browse/GOMO-103?atlOrigin=eyJpIjoiMDFjNGE2N2NkMTFhNGNlZTgwMmVmZDMzMjdmZGI4NDAiLCJwIjoiaiJ9)

<br>

### 내용

**주의! 본 PR을 Merge하게되면, application.yml을 업데이트 해야합니다.**

**OAuth2를 확장 가능하도록 설계를 변경하였습니다.**
- [x] OauthProvider interface와 Factory를 추가하여, 확장가능한 설계를 적용하였습니다.

**OAuth2 Proiver 를 추가하였습니다.**
- [x] LoginProvider의 Enum 값을 추가하였습니다. (NAVER, KAKAO)
- [x] NaverOAuthProvider를 추가하였습니다.
- [x] KakaoOAuthProvider를 추가하였습니다.

[GOMO-103]: https://kkj1250.atlassian.net/browse/GOMO-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ