### PR TITLE
[GOMO-108] DisplayOrder 변경 기능 수정

### DIFF
--- a/src/main/java/com/gomo/app/common/domain/service/OrderChanger.java
+++ b/src/main/java/com/gomo/app/common/domain/service/OrderChanger.java
@@ -1,24 +1,26 @@
 package com.gomo.app.common.domain.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Component;
 
-import com.gomo.app.common.exception.DomainErrorCode;
-import com.gomo.app.common.exception.PolicyViolationException;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 
 @Component
 public class OrderChanger {
 
-	public static void change(List<OrderChangeable> candidates, List<DisplayOrder> changedOrders) {
-		ensureCandidatesSize(candidates, changedOrders);
-		IntStream.range(0, candidates.size()).forEach(i -> candidates.get(i).changeOrder(changedOrders.get(i)));
-	}
+	public static void change(Map<UUID, OrderChangeable> orderChangeableMap, List<UpdateOrderRequest> updateOrderRequests) {
+		List<OrderChangeable> candidates = updateOrderRequests.stream()
+			.map(updateOrderRequest -> orderChangeableMap.get(updateOrderRequest.getId()))
+			.toList();
 
-	private static void ensureCandidatesSize(List<OrderChangeable> candidates, List<DisplayOrder> changedOrders) {
-		if(candidates.size() != changedOrders.size()) {
-			throw new PolicyViolationException(DomainErrorCode.INVALID_PARAMETER, "Candidates size and changed orders size must be the same");
-		}
+		List<DisplayOrder> changedOrders = updateOrderRequests.stream()
+			.map(updateOrderRequest -> DisplayOrder.of(updateOrderRequest.getDisplayOrder()))
+			.toList();
+
+		IntStream.range(0, candidates.size()).forEach(i -> candidates.get(i).changeOrder(changedOrders.get(i)));
 	}
 }

--- a/src/main/java/com/gomo/app/interest/application/OrderUpdateMajorInterestUseCase.java
+++ b/src/main/java/com/gomo/app/interest/application/OrderUpdateMajorInterestUseCase.java
@@ -1,12 +1,12 @@
 package com.gomo.app.interest.application;
 
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gomo.app.common.application.ApplicationService;
-import com.gomo.app.common.domain.service.DisplayOrder;
 import com.gomo.app.common.domain.service.OrderChangeable;
 import com.gomo.app.common.domain.service.OrderChanger;
 import com.gomo.app.interest.domain.model.RegistrantId;
@@ -23,13 +23,12 @@ public class OrderUpdateMajorInterestUseCase {
 	private final MajorInterestRepository majorInterestRepository;
 
 	public void update(UUID accessorId, OrderUpdateMajorInterestRequest request) {
-		List<OrderChangeable> majorInterests = majorInterestRepository.findAllByRegistrantIdOrderByDisplayOrder(RegistrantId.of(accessorId)).stream()
-			.map(majorInterest -> (OrderChangeable) majorInterest)
-			.toList();
-		List<DisplayOrder> changedOrders = request.getUpdatedOrders().stream()
-			.map(DisplayOrder::of)
-			.toList();
+		Map<UUID, OrderChangeable> majorInterestMap = majorInterestRepository.findAllByRegistrantIdOrderByDisplayOrder(RegistrantId.of(accessorId)).stream()
+			.collect(Collectors.toMap(
+					majorInterest -> majorInterest.getId().getId(),
+					majorInterest -> majorInterest
+			));
 
-		OrderChanger.change(majorInterests, changedOrders);
+		OrderChanger.change(majorInterestMap, request.getUpdateOrderRequests());
 	}
 }

--- a/src/main/java/com/gomo/app/interest/presentation/request/OrderUpdateMajorInterestRequest.java
+++ b/src/main/java/com/gomo/app/interest/presentation/request/OrderUpdateMajorInterestRequest.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @Getter
 public class OrderUpdateMajorInterestRequest {
 
-	private List<Integer> updatedOrders;
+	private List<UpdateOrderRequest> updateOrderRequests;
 
-	private OrderUpdateMajorInterestRequest(List<Integer> updatedOrders) {
-		this.updatedOrders = updatedOrders;
+	private OrderUpdateMajorInterestRequest(List<UpdateOrderRequest> updateOrderRequests) {
+		this.updateOrderRequests = updateOrderRequests;
 	}
 
-	public static OrderUpdateMajorInterestRequest of(List<Integer> updatedOrders) {
+	public static OrderUpdateMajorInterestRequest of(List<UpdateOrderRequest> updatedOrders) {
 		return new OrderUpdateMajorInterestRequest(updatedOrders);
 	}
 }

--- a/src/main/java/com/gomo/app/interest/presentation/request/UpdateOrderRequest.java
+++ b/src/main/java/com/gomo/app/interest/presentation/request/UpdateOrderRequest.java
@@ -1,0 +1,26 @@
+package com.gomo.app.interest.presentation.request;
+
+import java.util.UUID;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateOrderRequest {
+
+	private UUID id;
+	private int displayOrder;
+
+	private UpdateOrderRequest(
+		UUID id,
+		int displayOrder
+	) {
+		this.id = id;
+		this.displayOrder = displayOrder;
+	}
+
+	public static UpdateOrderRequest of(UUID candidateId,
+		int displayOrder
+	) {
+		return new UpdateOrderRequest(candidateId, displayOrder);
+	}
+}

--- a/src/main/java/com/gomo/app/quest/application/OrderUpdateAssignQuestUseCase.java
+++ b/src/main/java/com/gomo/app/quest/application/OrderUpdateAssignQuestUseCase.java
@@ -1,13 +1,13 @@
 package com.gomo.app.quest.application;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gomo.app.common.application.ApplicationService;
-import com.gomo.app.common.domain.service.DisplayOrder;
 import com.gomo.app.common.domain.service.OrderChangeable;
 import com.gomo.app.common.domain.service.OrderChanger;
 import com.gomo.app.common.util.DateRangeCalculator;
@@ -27,20 +27,17 @@ public class OrderUpdateAssignQuestUseCase {
 	public void update(UUID accessorId, OrderUpdateAssignQuestRequest request) {
 		LocalDate now = LocalDate.now();
 
-		List<OrderChangeable> assignQuests = assignQuestRepository.findParticipatingQuestByQuestTypeWithoutCompleted(
+		Map<UUID, OrderChangeable> assignQuestMap = assignQuestRepository.findParticipatingQuestByQuestTypeWithoutCompleted(
 				ParticipantId.of(accessorId),
 				request.getQuestType(),
 				DateRangeCalculator.startOf(now, request.getQuestType().name()),
 				DateRangeCalculator.endOf(now, request.getQuestType().name())
-			)
-			.stream()
-			.map(assignQuest -> (OrderChangeable)assignQuest)
-			.toList();
+			).stream()
+			.collect(Collectors.toMap(
+				assignQuest -> assignQuest.getId().getId(),
+				assignQuest -> assignQuest
+			));
 
-		List<DisplayOrder> changedOrders = request.getUpdatedOrders().stream()
-			.map(DisplayOrder::of)
-			.toList();
-
-		OrderChanger.change(assignQuests, changedOrders);
+		OrderChanger.change(assignQuestMap, request.getUpdateOrderRequests());
 	}
 }

--- a/src/main/java/com/gomo/app/quest/application/OrderUpdateRepeatQuestUseCase.java
+++ b/src/main/java/com/gomo/app/quest/application/OrderUpdateRepeatQuestUseCase.java
@@ -1,12 +1,12 @@
 package com.gomo.app.quest.application;
 
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.transaction.annotation.Transactional;
 
 import com.gomo.app.common.application.ApplicationService;
-import com.gomo.app.common.domain.service.DisplayOrder;
 import com.gomo.app.common.domain.service.OrderChangeable;
 import com.gomo.app.common.domain.service.OrderChanger;
 import com.gomo.app.quest.domain.model.ParticipantId;
@@ -23,18 +23,15 @@ public class OrderUpdateRepeatQuestUseCase {
 	private final RepeatQuestRepository repeatQuestRepository;
 
 	public void update(UUID accessorId, OrderUpdateRepeatQuestRequest request) {
-		List<OrderChangeable> repeatQuests = repeatQuestRepository.findRepeatQuestsByQuestType(
+		Map<UUID, OrderChangeable> repeatQuestMap = repeatQuestRepository.findRepeatQuestsByQuestType(
 				ParticipantId.of(accessorId),
 				request.getQuestType()
-			)
-			.stream()
-			.map(repeatQuest -> (OrderChangeable)repeatQuest)
-			.toList();
+			).stream()
+			.collect(Collectors.toMap(
+				repeatQuest -> repeatQuest.getId().getId(),
+				repeatQuest -> repeatQuest
+			));
 
-		List<DisplayOrder> changedOrders = request.getUpdatedOrders().stream()
-			.map(DisplayOrder::of)
-			.toList();
-
-		OrderChanger.change(repeatQuests, changedOrders);
+		OrderChanger.change(repeatQuestMap, request.getUpdateOrderRequests());
 	}
 }

--- a/src/main/java/com/gomo/app/quest/presentation/request/OrderUpdateAssignQuestRequest.java
+++ b/src/main/java/com/gomo/app/quest/presentation/request/OrderUpdateAssignQuestRequest.java
@@ -2,6 +2,7 @@ package com.gomo.app.quest.presentation.request;
 
 import java.util.List;
 
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 import com.gomo.app.quest.domain.model.QuestType;
 
 import lombok.Getter;
@@ -10,19 +11,19 @@ import lombok.Getter;
 public class OrderUpdateAssignQuestRequest {
 
 	private QuestType questType;
-	private List<Integer> updatedOrders;
+	private List<UpdateOrderRequest> updateOrderRequests;
 
 	private OrderUpdateAssignQuestRequest(
 		QuestType questType,
-		List<Integer> updatedOrders
+		List<UpdateOrderRequest> updateOrderRequests
 	) {
 		this.questType = questType;
-		this.updatedOrders = updatedOrders;
+		this.updateOrderRequests = updateOrderRequests;
 	}
 
 	public static OrderUpdateAssignQuestRequest of(
 		QuestType questType,
-		List<Integer> updatedOrders
+		List<UpdateOrderRequest> updatedOrders
 	) {
 		return new OrderUpdateAssignQuestRequest(questType, updatedOrders);
 	}

--- a/src/main/java/com/gomo/app/quest/presentation/request/OrderUpdateRepeatQuestRequest.java
+++ b/src/main/java/com/gomo/app/quest/presentation/request/OrderUpdateRepeatQuestRequest.java
@@ -2,6 +2,7 @@ package com.gomo.app.quest.presentation.request;
 
 import java.util.List;
 
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 import com.gomo.app.quest.domain.model.QuestType;
 
 import lombok.Getter;
@@ -10,19 +11,19 @@ import lombok.Getter;
 public class OrderUpdateRepeatQuestRequest {
 
 	private QuestType questType;
-	private List<Integer> updatedOrders;
+	private List<UpdateOrderRequest> updateOrderRequests;
 
 	private OrderUpdateRepeatQuestRequest(
 		QuestType questType,
-		List<Integer> updatedOrders
+		List<UpdateOrderRequest> updateOrderRequests
 	) {
 		this.questType = questType;
-		this.updatedOrders = updatedOrders;
+		this.updateOrderRequests = updateOrderRequests;
 	}
 
 	public static OrderUpdateRepeatQuestRequest of(
 		QuestType questType,
-		List<Integer> updatedOrders
+		List<UpdateOrderRequest> updatedOrders
 	) {
 		return new OrderUpdateRepeatQuestRequest(questType, updatedOrders);
 	}

--- a/src/main/java/com/gomo/app/quest/presentation/request/UpdateOrderRequest.java
+++ b/src/main/java/com/gomo/app/quest/presentation/request/UpdateOrderRequest.java
@@ -1,0 +1,26 @@
+package com.gomo.app.quest.presentation.request;
+
+import java.util.UUID;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateOrderRequest {
+
+	private UUID id;
+	private int displayOrder;
+
+	public UpdateOrderRequest(
+		UUID id,
+		int displayOrder
+	) {
+		this.id = id;
+		this.displayOrder = displayOrder;
+	}
+
+	public static UpdateOrderRequest of(UUID candidateId,
+		int displayOrder
+	) {
+		return new UpdateOrderRequest(candidateId, displayOrder);
+	}
+}

--- a/src/test/java/com/gomo/app/common/unit/OrderChangerTest.java
+++ b/src/test/java/com/gomo/app/common/unit/OrderChangerTest.java
@@ -2,44 +2,69 @@ package com.gomo.app.common.unit;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.gomo.app.common.domain.service.DisplayOrder;
 import com.gomo.app.common.domain.service.OrderChangeable;
 import com.gomo.app.common.domain.service.OrderChanger;
-import com.gomo.app.common.exception.PolicyViolationException;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 
 import lombok.Getter;
 
 @DisplayName("[Domain service]: 정렬 순서 변경 테스트")
 public class OrderChangerTest {
 
+	private static final UUID FIRST_CANDIDATE_ID = UUID.randomUUID();
+	private static final UUID SECOND_CANDIDATE_ID = UUID.randomUUID();
+	private static final UUID THIRD_CANDIDATE_ID = UUID.randomUUID();
+
 	@DisplayName("정렬 순서를 변경한다.")
 	@Test
 	void change_display_order() {
-		List<OrderChangeable> candidates = List.of(MockOrderChangeable.of(1), MockOrderChangeable.of(2), MockOrderChangeable.of(3));
-		List<DisplayOrder> changedOrders = List.of(DisplayOrder.of(3), DisplayOrder.of(2), DisplayOrder.of(1));
+		Map<UUID, OrderChangeable> candidates = getOrderChangeableMap();
+		List<UpdateOrderRequest> changedOrders = getRequests();
 
 		OrderChanger.change(candidates, changedOrders);
 
-		assertThat(candidates)
+		assertThat(candidates.values())
 			.extracting(candidate -> ((MockOrderChangeable)candidate).getDisplayOrder())
 			.containsExactly(DisplayOrder.of(3), DisplayOrder.of(2), DisplayOrder.of(1));
 	}
 
-	@DisplayName("정렬 대상과 변경된 순서의 크기가 다르면 변경할 수 없다.")
+	@DisplayName("정렬 대상이 존재하지 않으면 변경에 실패한다.")
 	@Test
 	void change_display_order_not_same_size() {
-		List<OrderChangeable> candidates = List.of(MockOrderChangeable.of(1), MockOrderChangeable.of(2));
-		List<DisplayOrder> changedOrders = List.of(DisplayOrder.of(3), DisplayOrder.of(2), DisplayOrder.of(1));
+		Map<UUID, OrderChangeable> candidates = getOrderChangeableMap();
+		List<UpdateOrderRequest> changedOrders = getRequests();
+
+		changedOrders.add(UpdateOrderRequest.of(UUID.randomUUID(), 4));
 
 		assertThatThrownBy(() -> OrderChanger.change(candidates, changedOrders))
-			.isInstanceOf(PolicyViolationException.class)
-			.hasMessageContaining("Candidates size and changed orders size must be the same");
+			.isInstanceOf(NullPointerException.class);
+	}
 
+	private static @NotNull Map<UUID, OrderChangeable> getOrderChangeableMap() {
+		Map<UUID, OrderChangeable> map = new LinkedHashMap<>();
+		map.put(FIRST_CANDIDATE_ID, MockOrderChangeable.of(1));
+		map.put(SECOND_CANDIDATE_ID, MockOrderChangeable.of(2));
+		map.put(THIRD_CANDIDATE_ID, MockOrderChangeable.of(3));
+		return map;
+	}
+
+	private @NotNull List<UpdateOrderRequest> getRequests() {
+		List<UpdateOrderRequest> requests = new ArrayList<>();
+		requests.add(UpdateOrderRequest.of(SECOND_CANDIDATE_ID, 2));
+		requests.add(UpdateOrderRequest.of(THIRD_CANDIDATE_ID, 1));
+		requests.add(UpdateOrderRequest.of(FIRST_CANDIDATE_ID, 3));
+		return requests;
 	}
 
 	@Getter

--- a/src/test/java/com/gomo/app/interest/documentation/OrderUpdateMajorInterestDocumentationTest.java
+++ b/src/test/java/com/gomo/app/interest/documentation/OrderUpdateMajorInterestDocumentationTest.java
@@ -1,22 +1,27 @@
 package com.gomo.app.interest.documentation;
 
-import com.gomo.app.common.DocumentationTestBase;
-import com.gomo.app.interest.common.util.MajorInterestDataHelper;
-import com.gomo.app.interest.documentation.snippet.OrderUpdateMajorInterestSnippet;
-import com.gomo.app.interest.presentation.request.OrderUpdateMajorInterestRequest;
+import static io.restassured.RestAssured.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.MediaType.*;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
-import java.util.List;
-
-import static io.restassured.RestAssured.given;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import com.gomo.app.common.DocumentationTestBase;
+import com.gomo.app.interest.common.dataprovider.MajorInterestDataProvider;
+import com.gomo.app.interest.common.util.MajorInterestDataHelper;
+import com.gomo.app.interest.documentation.snippet.OrderUpdateMajorInterestSnippet;
+import com.gomo.app.interest.domain.model.MajorInterest;
+import com.gomo.app.interest.presentation.request.OrderUpdateMajorInterestRequest;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 
 @DisplayName("[Presentation documentation]: 주요 관심사 정렬 순서 변경 테스트")
 public class OrderUpdateMajorInterestDocumentationTest extends DocumentationTestBase {
@@ -25,6 +30,17 @@ public class OrderUpdateMajorInterestDocumentationTest extends DocumentationTest
 
 	@Autowired
 	private MajorInterestDataHelper majorInterestDataHelper;
+
+	@Autowired
+	private MajorInterestDataProvider majorInterestDataProvider;
+	private MajorInterest majorInterestA;
+	private MajorInterest majorInterestB;
+
+	@BeforeEach
+	void setup() {
+		majorInterestA = majorInterestDataProvider.java();
+		majorInterestB = majorInterestDataProvider.spring();
+	}
 
 	@AfterEach
 	void tearDown() {
@@ -37,10 +53,19 @@ public class OrderUpdateMajorInterestDocumentationTest extends DocumentationTest
 		given(this.specification).filter(filter)
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 			.header(AUTHORIZATION, "Bearer " + accessToken)
-			.body(OrderUpdateMajorInterestRequest.of(List.of(2, 1)))
+			.body(getRequest())
 			.when()
 			.put("/interests/majors/orders")
 			.then()
 			.statusCode(NO_CONTENT.value());
+	}
+
+	private @NotNull OrderUpdateMajorInterestRequest getRequest() {
+		return OrderUpdateMajorInterestRequest.of(
+			List.of(
+				UpdateOrderRequest.of(majorInterestA.getId().getId(), 2),
+				UpdateOrderRequest.of(majorInterestB.getId().getId(), 1)
+			)
+		);
 	}
 }

--- a/src/test/java/com/gomo/app/interest/documentation/snippet/OrderUpdateMajorInterestSnippet.java
+++ b/src/test/java/com/gomo/app/interest/documentation/snippet/OrderUpdateMajorInterestSnippet.java
@@ -1,15 +1,15 @@
 package com.gomo.app.interest.documentation.snippet;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.gomo.app.common.constant.ErrorResponseFields;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import org.springframework.restdocs.snippet.Snippet;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.gomo.app.common.constant.ErrorResponseFields;
 
 public class OrderUpdateMajorInterestSnippet {
 
@@ -19,7 +19,9 @@ public class OrderUpdateMajorInterestSnippet {
 	private static final String TAG = "Interest";
 
 	private static final Snippet REQUEST_FIELDS = requestFields(
-		fieldWithPath("updatedOrders").type(JsonFieldType.ARRAY).description("변경하려는 정렬 순서")
+		fieldWithPath("updateOrderRequests").type(JsonFieldType.ARRAY).description("변경 대상 정보"),
+		fieldWithPath("updateOrderRequests[].id").type(JsonFieldType.STRING).description("변경 대상 주요 관심사 아이디"),
+		fieldWithPath("updateOrderRequests[].displayOrder").type(JsonFieldType.NUMBER).description("변경하려는 정렬 순서")
 	);
 
 	public static RestDocumentationFilter create() {

--- a/src/test/java/com/gomo/app/interest/unit/usecase/OrderUpdateMajorInterestUseCaseTest.java
+++ b/src/test/java/com/gomo/app/interest/unit/usecase/OrderUpdateMajorInterestUseCaseTest.java
@@ -20,6 +20,7 @@ import com.gomo.app.interest.common.fixture.MajorInterestFixture;
 import com.gomo.app.interest.domain.model.MajorInterest;
 import com.gomo.app.interest.domain.repository.MajorInterestRepository;
 import com.gomo.app.interest.presentation.request.OrderUpdateMajorInterestRequest;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 
 @DisplayName("[Application unit]: 주요 관심사 정렬 순서 변경 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -34,22 +35,31 @@ public class OrderUpdateMajorInterestUseCaseTest {
 	@DisplayName("주요 관심사 정렬 순서를 변경한다.")
 	@Test
 	void update_interest_display_order() {
-		OrderUpdateMajorInterestRequest request = OrderUpdateMajorInterestRequest.of(List.of(3, 2, 1));
 		doReturn(getMajorInterests()).when(majorInterestRepository).findAllByRegistrantIdOrderByDisplayOrder(any());
 
 		try (MockedStatic<OrderChanger> mockedOrderChanger = mockStatic(OrderChanger.class)) {
-			sut.update(UUID.randomUUID(), request);
+			sut.update(UUID.randomUUID(), getRequest());
 
 			verify(majorInterestRepository, times(1)).findAllByRegistrantIdOrderByDisplayOrder(any());
 			mockedOrderChanger.verify(() -> OrderChanger.change(any(), any()), times(1));
 		}
 	}
 
-	private static @NotNull List<MajorInterest> getMajorInterests() {
+	private @NotNull OrderUpdateMajorInterestRequest getRequest() {
+		return OrderUpdateMajorInterestRequest.of(
+			List.of(
+				UpdateOrderRequest.of(UUID.randomUUID(), 1),
+				UpdateOrderRequest.of(UUID.randomUUID(), 2),
+				UpdateOrderRequest.of(UUID.randomUUID(), 3)
+			)
+		);
+	}
+
+	private @NotNull List<MajorInterest> getMajorInterests() {
 		return List.of(
-			MajorInterestFixture.majorInterest(1),
-			MajorInterestFixture.majorInterest(2),
-			MajorInterestFixture.majorInterest(3)
+			MajorInterestFixture.majorInterest(),
+			MajorInterestFixture.majorInterest(),
+			MajorInterestFixture.majorInterest()
 		);
 	}
 }

--- a/src/test/java/com/gomo/app/quest/documentation/OrderUpdateAssignQuestDocumentationTest.java
+++ b/src/test/java/com/gomo/app/quest/documentation/OrderUpdateAssignQuestDocumentationTest.java
@@ -7,15 +7,20 @@ import static org.springframework.http.MediaType.*;
 
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 import com.gomo.app.common.DocumentationTestBase;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
+import com.gomo.app.quest.common.dataprovider.AssignQuestDataProvider;
 import com.gomo.app.quest.common.util.AssignQuestDataHelper;
 import com.gomo.app.quest.documentation.snippet.OrderUpdateAssignQuestSnippet;
+import com.gomo.app.quest.domain.model.AssignQuest;
 import com.gomo.app.quest.domain.model.QuestType;
 import com.gomo.app.quest.presentation.request.OrderUpdateAssignQuestRequest;
 
@@ -26,6 +31,15 @@ public class OrderUpdateAssignQuestDocumentationTest extends DocumentationTestBa
 
 	@Autowired
 	private AssignQuestDataHelper assignQuestDataHelper;
+
+	@Autowired
+	private AssignQuestDataProvider assignQuestDataProvider;
+	private AssignQuest assignQuest;
+
+	@BeforeEach
+	void setup() {
+		assignQuest = assignQuestDataProvider.dailyParticipatingQuest();
+	}
 
 	@AfterEach
 	void tearDown() {
@@ -38,10 +52,20 @@ public class OrderUpdateAssignQuestDocumentationTest extends DocumentationTestBa
 		given(this.specification).filter(filter)
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 			.header(AUTHORIZATION, "Bearer " + accessToken)
-			.body(OrderUpdateAssignQuestRequest.of(QuestType.DAILY, List.of(1)))
+			.body(getRequest())
 			.when()
 			.put("/quests/assigns/orders")
 			.then()
 			.statusCode(NO_CONTENT.value());
+	}
+
+	// TODO <jhl221123>: 픽스처 관리방식 변경 후, 두 개 이상 원소를 사용할 것
+	private @NotNull OrderUpdateAssignQuestRequest getRequest() {
+		return OrderUpdateAssignQuestRequest.of(
+			QuestType.DAILY,
+			List.of(
+				UpdateOrderRequest.of(assignQuest.getId().getId(), 1)
+			)
+		);
 	}
 }

--- a/src/test/java/com/gomo/app/quest/documentation/OrderUpdateRepeatQuestDocumentationTest.java
+++ b/src/test/java/com/gomo/app/quest/documentation/OrderUpdateRepeatQuestDocumentationTest.java
@@ -7,16 +7,21 @@ import static org.springframework.http.MediaType.*;
 
 import java.util.List;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 import com.gomo.app.common.DocumentationTestBase;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
+import com.gomo.app.quest.common.dataprovider.RepeatQuestDataProvider;
 import com.gomo.app.quest.common.util.RepeatQuestDataHelper;
 import com.gomo.app.quest.documentation.snippet.OrderUpdateRepeatQuestSnippet;
 import com.gomo.app.quest.domain.model.QuestType;
+import com.gomo.app.quest.domain.model.RepeatQuest;
 import com.gomo.app.quest.presentation.request.OrderUpdateRepeatQuestRequest;
 
 @DisplayName("[Presentation documentation]: 반복 퀘스트 순서 변경 테스트")
@@ -26,6 +31,17 @@ public class OrderUpdateRepeatQuestDocumentationTest extends DocumentationTestBa
 
 	@Autowired
 	private RepeatQuestDataHelper repeatQuestDataHelper;
+
+	@Autowired
+	private RepeatQuestDataProvider repeatQuestDataProvider;
+	private RepeatQuest repeatQuestA;
+	private RepeatQuest repeatQuestB;
+
+	@BeforeEach
+	void setup() {
+		repeatQuestA = repeatQuestDataProvider.firstOrderDaily();
+		repeatQuestB = repeatQuestDataProvider.secondOrderDaily();
+	}
 
 	@AfterEach
 	void tearDown() {
@@ -38,12 +54,20 @@ public class OrderUpdateRepeatQuestDocumentationTest extends DocumentationTestBa
 		given(this.specification).filter(filter)
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 			.header(AUTHORIZATION, "Bearer " + accessToken)
-			.body(OrderUpdateRepeatQuestRequest.of(
-				QuestType.DAILY,
-				List.of(2, 1)))
+			.body(getRequest())
 			.when()
 			.put("/quests/repeats/orders")
 			.then()
 			.statusCode(NO_CONTENT.value());
+	}
+
+	private @NotNull OrderUpdateRepeatQuestRequest getRequest() {
+		return OrderUpdateRepeatQuestRequest.of(
+			QuestType.DAILY,
+			List.of(
+				UpdateOrderRequest.of(repeatQuestA.getId().getId(), 2),
+				UpdateOrderRequest.of(repeatQuestB.getId().getId(), 1)
+			)
+		);
 	}
 }

--- a/src/test/java/com/gomo/app/quest/documentation/snippet/OrderUpdateAssignQuestSnippet.java
+++ b/src/test/java/com/gomo/app/quest/documentation/snippet/OrderUpdateAssignQuestSnippet.java
@@ -20,7 +20,9 @@ public class OrderUpdateAssignQuestSnippet {
 
 	private static final Snippet REQUEST_FIELDS = requestFields(
 		fieldWithPath("questType").type(JsonFieldType.STRING).description("퀘스트 타입: DAILY / WEEKLY / MONTHLY"),
-		fieldWithPath("updatedOrders").type(JsonFieldType.ARRAY).description("변경하려는 정렬 순서")
+		fieldWithPath("updateOrderRequests").type(JsonFieldType.ARRAY).description("변경 대상 정보"),
+		fieldWithPath("updateOrderRequests[].id").type(JsonFieldType.STRING).description("변경 대상 할당 퀘스트 아이디"),
+		fieldWithPath("updateOrderRequests[].displayOrder").type(JsonFieldType.NUMBER).description("변경하려는 정렬 순서")
 	);
 
 	public static RestDocumentationFilter create() {

--- a/src/test/java/com/gomo/app/quest/documentation/snippet/OrderUpdateRepeatQuestSnippet.java
+++ b/src/test/java/com/gomo/app/quest/documentation/snippet/OrderUpdateRepeatQuestSnippet.java
@@ -20,7 +20,9 @@ public class OrderUpdateRepeatQuestSnippet {
 
 	private static final Snippet REQUEST_FIELDS = requestFields(
 		fieldWithPath("questType").type(JsonFieldType.STRING).description("퀘스트 타입: DAILY / WEEKLY / MONTHLY"),
-		fieldWithPath("updatedOrders").type(JsonFieldType.ARRAY).description("변경하려는 정렬 순서")
+		fieldWithPath("updateOrderRequests").type(JsonFieldType.ARRAY).description("변경 대상 정보"),
+		fieldWithPath("updateOrderRequests[].id").type(JsonFieldType.STRING).description("변경 대상 반복 퀘스트 아이디"),
+		fieldWithPath("updateOrderRequests[].displayOrder").type(JsonFieldType.NUMBER).description("변경하려는 정렬 순서")
 	);
 
 	public static RestDocumentationFilter create() {

--- a/src/test/java/com/gomo/app/quest/unit/usecase/OrderUpdateAssignQuestUseCaseTest.java
+++ b/src/test/java/com/gomo/app/quest/unit/usecase/OrderUpdateAssignQuestUseCaseTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.gomo.app.common.domain.service.OrderChanger;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 import com.gomo.app.quest.application.OrderUpdateAssignQuestUseCase;
 import com.gomo.app.quest.common.fixture.AssignQuestFixture;
 import com.gomo.app.quest.domain.model.AssignQuest;
@@ -35,7 +36,7 @@ public class OrderUpdateAssignQuestUseCaseTest {
 	@DisplayName("참여 중인 퀘스트의 정렬 순서를 변경한다.")
 	@Test
 	void update_participating_quest_display_order() {
-		OrderUpdateAssignQuestRequest request = OrderUpdateAssignQuestRequest.of(QuestType.DAILY, List.of(3, 2, 1));
+		OrderUpdateAssignQuestRequest request = getRequest();
 		doReturn(getParticipatingQuests()).when(assignQuestRepository).findParticipatingQuestByQuestTypeWithoutCompleted(any(), any(), any(), any());
 
 		try (MockedStatic<OrderChanger> mockedOrderChanger = mockStatic(OrderChanger.class)) {
@@ -46,7 +47,18 @@ public class OrderUpdateAssignQuestUseCaseTest {
 		}
 	}
 
-	private static @NotNull List<AssignQuest> getParticipatingQuests() {
+	private @NotNull OrderUpdateAssignQuestRequest getRequest() {
+		return OrderUpdateAssignQuestRequest.of(
+			QuestType.DAILY,
+			List.of(
+				UpdateOrderRequest.of(UUID.randomUUID(), 1),
+				UpdateOrderRequest.of(UUID.randomUUID(), 2),
+				UpdateOrderRequest.of(UUID.randomUUID(), 3)
+			)
+		);
+	}
+
+	private @NotNull List<AssignQuest> getParticipatingQuests() {
 		return List.of(
 			AssignQuestFixture.assignQuest(1),
 			AssignQuestFixture.assignQuest(2),

--- a/src/test/java/com/gomo/app/quest/unit/usecase/OrderUpdateRepeatQuestUseCaseTest.java
+++ b/src/test/java/com/gomo/app/quest/unit/usecase/OrderUpdateRepeatQuestUseCaseTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.gomo.app.common.domain.service.OrderChanger;
+import com.gomo.app.interest.presentation.request.UpdateOrderRequest;
 import com.gomo.app.quest.application.OrderUpdateRepeatQuestUseCase;
 import com.gomo.app.quest.common.fixture.RepeatQuestFixture;
 import com.gomo.app.quest.domain.model.QuestType;
@@ -35,7 +36,7 @@ public class OrderUpdateRepeatQuestUseCaseTest {
 	@DisplayName("반복 퀘스트의 정렬 순서를 변경한다.")
 	@Test
 	void update_repeat_quest_display_order() {
-		OrderUpdateRepeatQuestRequest request = OrderUpdateRepeatQuestRequest.of(QuestType.DAILY, List.of(3, 2, 1));
+		OrderUpdateRepeatQuestRequest request = getRequest();
 		doReturn(getRepeatQuests()).when(repeatQuestRepository).findRepeatQuestsByQuestType(any(), any());
 
 		try (MockedStatic<OrderChanger> mockedOrderChanger = mockStatic(OrderChanger.class)) {
@@ -44,6 +45,17 @@ public class OrderUpdateRepeatQuestUseCaseTest {
 			verify(repeatQuestRepository, times(1)).findRepeatQuestsByQuestType(any(), any());
 			mockedOrderChanger.verify(() -> OrderChanger.change(any(), any()), times(1));
 		}
+	}
+
+	private @NotNull OrderUpdateRepeatQuestRequest getRequest() {
+		return OrderUpdateRepeatQuestRequest.of(
+			QuestType.DAILY,
+			List.of(
+				UpdateOrderRequest.of(UUID.randomUUID(), 1),
+				UpdateOrderRequest.of(UUID.randomUUID(), 2),
+				UpdateOrderRequest.of(UUID.randomUUID(), 3)
+			)
+		);
 	}
 
 	private static @NotNull List<RepeatQuest> getRepeatQuests() {


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** [#GOMO-108](https://kkj1250.atlassian.net/jira/software/projects/GOMO/boards/2?selectedIssue=GOMO-108)

<br>

### 내용

- [X] 주요 관심사, 할당 퀘스트, 반복 퀘스트의 정렬 순서를 식별자 기반으로 변경할 수 있도록 로직을 수정했습니다.
- [X] 관련 테스트 코드를 수정했습니다.