### PR TITLE
[GOMO-191] OAuth2 리팩토링

### DIFF
--- a/src/main/java/com/gomo/app/auth/application/OAuthUseCase.java
+++ b/src/main/java/com/gomo/app/auth/application/OAuthUseCase.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import com.gomo.app.auth.domain.model.AuthToken;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProvider;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProviderFactory;
-import com.gomo.app.auth.presentation.response.AuthTokenResponse;
-import com.gomo.app.auth.presentation.response.OAuthResponse;
 import com.gomo.app.auth.presentation.response.OAuthTokenResponse;
 import com.gomo.app.common.ApplicationService;
 import com.gomo.app.member.domain.model.Email;

--- a/src/main/java/com/gomo/app/auth/application/OAuthUseCase.java
+++ b/src/main/java/com/gomo/app/auth/application/OAuthUseCase.java
@@ -1,11 +1,14 @@
 package com.gomo.app.auth.application;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import com.gomo.app.auth.domain.model.AuthToken;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProvider;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProviderFactory;
 import com.gomo.app.auth.presentation.response.AuthTokenResponse;
+import com.gomo.app.auth.presentation.response.OAuthResponse;
+import com.gomo.app.auth.presentation.response.OAuthTokenResponse;
 import com.gomo.app.common.ApplicationService;
 import com.gomo.app.member.domain.model.Email;
 import com.gomo.app.member.domain.model.Member;
@@ -24,18 +27,22 @@ public class OAuthUseCase {
 	private final MemberRepository memberRepository;
 	private final AuthTokenGenerator authTokenGenerator;
 
-	public AuthTokenResponse login(String providerName, String code) {
+	public OAuthTokenResponse getUserInformation(String providerName, String code) {
 		OAuthProvider provider = providerFactory.getProvider(providerName);
 		OAuthUserInfo userInfo = provider.authenticate(code);
 
-		Member member = memberRepository.findByEmail(Email.of(userInfo.getEmail()))
-			.orElseGet(() -> memberService.oauthCreateMember(userInfo, providerName));
-		memberService.checkActivated(member);
-		member.updateLastLoginDateTime(LocalDateTime.now());
+		Optional<Member> member = memberRepository.findByEmail(Email.of(userInfo.getEmail()));
 
-		AuthToken authToken = authTokenGenerator.generate(member.uuid());
-		long refreshExpirationTime = authTokenGenerator.getRefreshTokenExpirationTime(authToken.getRefreshToken());
+		if (member.isPresent()) {
+			memberService.checkActivated(member.get());
+			member.get().updateLastLoginDateTime(LocalDateTime.now());
 
-		return AuthTokenResponse.of(member.uuid(), authToken, refreshExpirationTime);
+			AuthToken authToken = authTokenGenerator.generate(member.get().uuid());
+			long refreshExpirationTime = authTokenGenerator.getRefreshTokenExpirationTime(authToken.getRefreshToken());
+
+			return OAuthTokenResponse.of(member.get().uuid(), authToken, refreshExpirationTime, userInfo);
+		} else {
+			return OAuthTokenResponse.of(null, null, 0, userInfo);
+		}
 	}
 }

--- a/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/GoogleOAuthProvider.java
+++ b/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/GoogleOAuthProvider.java
@@ -9,6 +9,7 @@ import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProvider;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.model.OAuthUserInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -41,7 +42,7 @@ public class GoogleOAuthProvider implements OAuthProvider {
 		return OAuthUserInfo.builder()
 			.email(userInfo.get("email").asText())
 			.name(userInfo.get("name").asText())
-			.providerId("google")
+			.provider(LoginProvider.GOOGLE)
 			.build();
 	}
 

--- a/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/KakaoOAuthProvider.java
+++ b/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/KakaoOAuthProvider.java
@@ -13,6 +13,7 @@ import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProvider;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.model.OAuthUserInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class KakaoOAuthProvider implements OAuthProvider {
 		return OAuthUserInfo.builder()
 			.email(userInfo.get("email").asText())
 			.name(userInfo.get("profile").get("nickname").asText())
-			.providerId("kakao")
+			.provider(LoginProvider.KAKAO)
 			.build();
 	}
 

--- a/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/NaverOAuthProvider.java
+++ b/src/main/java/com/gomo/app/auth/infrastructure/oauth/providers/NaverOAuthProvider.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.gomo.app.auth.infrastructure.oauth.OAuthProvider;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.model.OAuthUserInfo;
 
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class NaverOAuthProvider implements OAuthProvider {
 		return OAuthUserInfo.builder()
 			.email(userInfo.get("email").asText())
 			.name(userInfo.get("name").asText())
-			.providerId("naver")
+			.provider(LoginProvider.NAVER)
 			.build();
 	}
 

--- a/src/main/java/com/gomo/app/auth/presentation/OAuthApi.java
+++ b/src/main/java/com/gomo/app/auth/presentation/OAuthApi.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.gomo.app.auth.application.OAuthUseCase;
-import com.gomo.app.auth.presentation.response.AuthTokenResponse;
-import com.gomo.app.auth.presentation.response.LoginMemberResponse;
 import com.gomo.app.auth.presentation.response.OAuthResponse;
 import com.gomo.app.auth.presentation.response.OAuthTokenResponse;
 import com.gomo.app.common.Presentation;

--- a/src/main/java/com/gomo/app/auth/presentation/OAuthApi.java
+++ b/src/main/java/com/gomo/app/auth/presentation/OAuthApi.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.gomo.app.auth.application.OAuthUseCase;
 import com.gomo.app.auth.presentation.response.AuthTokenResponse;
 import com.gomo.app.auth.presentation.response.LoginMemberResponse;
+import com.gomo.app.auth.presentation.response.OAuthResponse;
+import com.gomo.app.auth.presentation.response.OAuthTokenResponse;
 import com.gomo.app.common.Presentation;
 
 import lombok.RequiredArgsConstructor;
@@ -25,14 +27,14 @@ public class OAuthApi {
 	private final OAuthUseCase oauthUseCase;
 
 	@GetMapping("/{provider}")
-	public ResponseEntity<LoginMemberResponse> oauthLogin(@PathVariable String provider, @RequestParam String code) {
-		AuthTokenResponse tokens = oauthUseCase.login(provider, code);
+	public ResponseEntity<OAuthResponse> getUserInformation(@PathVariable String provider, @RequestParam String code) {
+		OAuthTokenResponse tokens = oauthUseCase.getUserInformation(provider, code);
 		ResponseCookie cookie = createResponseCookie(tokens.getAuthToken().getRefreshToken(),
 			tokens.getExpiresIn());
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(LoginMemberResponse.of(tokens.getMemberId(), tokens.getAuthToken().getAccessToken()));
+			.body(OAuthResponse.of(tokens.getAuthToken().getAccessToken(), tokens.getUserInfo()));
 	}
 
 	private ResponseCookie createResponseCookie(String refreshToken, long expiresIn) {

--- a/src/main/java/com/gomo/app/auth/presentation/response/OAuthResponse.java
+++ b/src/main/java/com/gomo/app/auth/presentation/response/OAuthResponse.java
@@ -1,0 +1,23 @@
+package com.gomo.app.auth.presentation.response;
+
+import java.util.UUID;
+
+import com.gomo.app.auth.domain.model.AuthToken;
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthResponse {
+	private String accessToken;
+	private OAuthUserInfo oauth;
+
+	private OAuthResponse(String accessToken, OAuthUserInfo oauth) {
+		this.accessToken = accessToken;
+		this.oauth = oauth;
+	}
+
+	public static OAuthResponse of(String accessToken, OAuthUserInfo oauth) {
+		return new OAuthResponse(accessToken, oauth);
+	}
+}

--- a/src/main/java/com/gomo/app/auth/presentation/response/OAuthResponse.java
+++ b/src/main/java/com/gomo/app/auth/presentation/response/OAuthResponse.java
@@ -1,8 +1,5 @@
 package com.gomo.app.auth.presentation.response;
 
-import java.util.UUID;
-
-import com.gomo.app.auth.domain.model.AuthToken;
 import com.gomo.app.member.domain.model.OAuthUserInfo;
 
 import lombok.Getter;
@@ -10,14 +7,14 @@ import lombok.Getter;
 @Getter
 public class OAuthResponse {
 	private String accessToken;
-	private OAuthUserInfo oauth;
+	private OAuthUserInfo userInfo;
 
-	private OAuthResponse(String accessToken, OAuthUserInfo oauth) {
+	private OAuthResponse(String accessToken, OAuthUserInfo userInfo) {
 		this.accessToken = accessToken;
-		this.oauth = oauth;
+		this.userInfo = userInfo;
 	}
 
-	public static OAuthResponse of(String accessToken, OAuthUserInfo oauth) {
-		return new OAuthResponse(accessToken, oauth);
+	public static OAuthResponse of(String accessToken, OAuthUserInfo userInfo) {
+		return new OAuthResponse(accessToken, userInfo);
 	}
 }

--- a/src/main/java/com/gomo/app/auth/presentation/response/OAuthTokenResponse.java
+++ b/src/main/java/com/gomo/app/auth/presentation/response/OAuthTokenResponse.java
@@ -1,0 +1,29 @@
+package com.gomo.app.auth.presentation.response;
+
+import java.util.UUID;
+
+import com.gomo.app.auth.domain.model.AuthToken;
+import com.gomo.app.member.domain.model.OAuthUserInfo;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthTokenResponse {
+
+	private UUID memberId;
+	private AuthToken authToken;
+	private long expiresIn;
+	private OAuthUserInfo userInfo;
+
+
+	private OAuthTokenResponse(UUID memberId, AuthToken authToken, long expiresIn, OAuthUserInfo userInfo) {
+		this.memberId = memberId;
+		this.authToken = authToken;
+		this.expiresIn = expiresIn;
+		this.userInfo = userInfo;
+	}
+
+	public static OAuthTokenResponse of(UUID memberId, AuthToken authToken, long expiresIn, OAuthUserInfo userInfo) {
+		return new OAuthTokenResponse(memberId, authToken, expiresIn, userInfo);
+	}
+}

--- a/src/main/java/com/gomo/app/member/application/CreateMemberUseCase.java
+++ b/src/main/java/com/gomo/app/member/application/CreateMemberUseCase.java
@@ -4,6 +4,7 @@ import com.gomo.app.common.ApplicationService;
 import com.gomo.app.common.util.UUIDGenerator;
 import com.gomo.app.member.domain.model.Email;
 import com.gomo.app.member.domain.model.Handle;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.model.Member;
 import com.gomo.app.member.domain.model.MemberId;
 import com.gomo.app.member.domain.repository.MemberRepository;
@@ -35,7 +36,7 @@ public class CreateMemberUseCase {
 		memberService.checkEmailDuplicated(Email.of(request.getEmail()));
 		memberService.checkHandleDuplicated(Handle.of(request.getHandle()));
 
-		Member member = request.toDomain(MemberId.of(UUIDGenerator.generate()), passwordService);
+		Member member = request.toDomain(MemberId.of(UUIDGenerator.generate()), LoginProvider.EMAIL, passwordService);
 		Member savedMember = memberRepository.save(member);
 		PointWallet pointWallet = PointWallet.createDefault(PointWalletId.of(UUIDGenerator.generate()),
 			TransactorId.of(savedMember.uuid()));

--- a/src/main/java/com/gomo/app/member/domain/model/OAuthUserInfo.java
+++ b/src/main/java/com/gomo/app/member/domain/model/OAuthUserInfo.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class OAuthUserInfo {
-    private String providerId;
+    private LoginProvider provider;
     private String email;
     private String name;
 }

--- a/src/main/java/com/gomo/app/member/presentation/request/CreateMemberRequest.java
+++ b/src/main/java/com/gomo/app/member/presentation/request/CreateMemberRequest.java
@@ -20,6 +20,7 @@ public class CreateMemberRequest {
 	private String handle;
 	private String name;
 	private String motto;
+	private LoginProvider loginProvider;
 
 	private CreateMemberRequest() {
 	}
@@ -29,13 +30,15 @@ public class CreateMemberRequest {
 		String password,
 		String handle,
 		String name,
-		String motto
+		String motto,
+		LoginProvider loginProvider
 	) {
 		this.email = email;
 		this.password = password;
 		this.handle = handle;
 		this.name = name;
 		this.motto = motto;
+		this.loginProvider = loginProvider;
 	}
 
 	public static CreateMemberRequest of(
@@ -43,15 +46,15 @@ public class CreateMemberRequest {
 		String password,
 		String handle,
 		String name,
-		String motto
+		String motto,
+		LoginProvider loginProvider
 	) {
-		return new CreateMemberRequest(email, password, handle, name, motto);
+		return new CreateMemberRequest(email, password, handle, name, motto, loginProvider);
 	}
 
-	public Member toDomain(MemberId memberId, PasswordService passwordService) {
+	public Member toDomain(MemberId memberId, LoginProvider loginProvider, PasswordService passwordService) {
 		Password newPw = Password.ofRaw(password);
 		return Member.of(memberId, Email.of(email), newPw.encodedWith(passwordService), Handle.of(handle),
-			MemberName.of(name), Motto.of(motto),
-			LoginProvider.EMAIL);
+			MemberName.of(name), Motto.of(motto), loginProvider);
 	}
 }

--- a/src/test/java/com/gomo/app/common/DocumentationTestBase.java
+++ b/src/test/java/com/gomo/app/common/DocumentationTestBase.java
@@ -23,6 +23,7 @@ import com.gomo.app.auth.presentation.AuthMemberApi;
 import com.gomo.app.auth.presentation.request.LoginMemberRequest;
 import com.gomo.app.common.authentication.AuthInfo;
 import com.gomo.app.common.config.RestAssureConfig;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.model.MemberId;
 import com.gomo.app.member.domain.repository.MemberRepository;
 import com.gomo.app.member.presentation.MemberApi;
@@ -75,7 +76,7 @@ public abstract class DocumentationTestBase {
 
 		sessionEmail = "testmember@naver.com";
 		sessionHandle = "@Test";
-		memberApi.create(CreateMemberRequest.of(sessionEmail, "Test1234@", sessionHandle, "testname", "testmotto"));
+		memberApi.create(CreateMemberRequest.of(sessionEmail, "Test1234@", sessionHandle, "testname", "testmotto", LoginProvider.EMAIL));
 		var tokenResponse = this.authMemberApi.login(LoginMemberRequest.of(sessionEmail, "Test1234@"));
 		this.sessionMemberId = tokenResponse.getBody().getMemberId();
 		this.authInfo = AuthInfo.of(sessionMemberId);

--- a/src/test/java/com/gomo/app/member/documentation/CreateMemberDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/CreateMemberDocumentationTest.java
@@ -14,6 +14,7 @@ import org.springframework.restdocs.restassured.RestDocumentationFilter;
 
 import com.gomo.app.common.DocumentationTestBase;
 import com.gomo.app.member.documentation.snippet.CreateMemberSnippet;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.domain.repository.MemberRepository;
 import com.gomo.app.member.presentation.request.CreateMemberRequest;
 
@@ -38,13 +39,14 @@ public class CreateMemberDocumentationTest extends DocumentationTestBase {
 	private static final String HANDLE = "@GOMOTEST3";
 	private static final String NAME = "gomotest3";
 	private static final String MOTTO = "TEST MOTTO";
+	private static final LoginProvider LOGIN_PROVIDER = LoginProvider.EMAIL;
 
 	@DisplayName("사용자를 등록한다.")
 	@Test
 	void create_member() {
 		given(this.specification).filter(filter)
 			.header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
-			.body(CreateMemberRequest.of(EMAIL, PASSWORD, HANDLE, NAME, MOTTO))
+			.body(CreateMemberRequest.of(EMAIL, PASSWORD, HANDLE, NAME, MOTTO, LOGIN_PROVIDER))
 			.when()
 			.post(CREATE_MEMBER_URL)
 			.then()

--- a/src/test/java/com/gomo/app/member/documentation/DeleteMemberDocumentationTest.java
+++ b/src/test/java/com/gomo/app/member/documentation/DeleteMemberDocumentationTest.java
@@ -15,6 +15,7 @@ import com.gomo.app.auth.application.LoginMemberUseCase;
 import com.gomo.app.common.DocumentationTestBase;
 import com.gomo.app.member.application.CreateMemberUseCase;
 import com.gomo.app.member.documentation.snippet.DeleteMemberSnippet;
+import com.gomo.app.member.domain.model.LoginProvider;
 import com.gomo.app.member.presentation.request.CreateMemberRequest;
 
 @DisplayName("[Presentation documentation]: 회원 탈퇴 테스트")
@@ -30,6 +31,7 @@ public class DeleteMemberDocumentationTest extends DocumentationTestBase {
 	private final String HANDLE = "@deletetester";
 	private final String NAME = "deleteTester";
 	private final String MOTTO = "MyMotto";
+	private static final LoginProvider LOGIN_PROVIDER = LoginProvider.EMAIL;
 
 	@Autowired
 	private CreateMemberUseCase createMemberUseCase;
@@ -39,7 +41,7 @@ public class DeleteMemberDocumentationTest extends DocumentationTestBase {
 
 	@BeforeEach
 	void setUp() {
-		CreateMemberRequest createMemberRequest = CreateMemberRequest.of(EMAIL, PASSWORD, HANDLE, NAME, MOTTO);
+		CreateMemberRequest createMemberRequest = CreateMemberRequest.of(EMAIL, PASSWORD, HANDLE, NAME, MOTTO, LOGIN_PROVIDER);
 		createMemberUseCase.create(createMemberRequest);
 
 		this.accessToken = loginMemberUseCase.login(EMAIL, PASSWORD).getAuthToken().getAccessToken();

--- a/src/test/java/com/gomo/app/member/documentation/snippet/CreateMemberSnippet.java
+++ b/src/test/java/com/gomo/app/member/documentation/snippet/CreateMemberSnippet.java
@@ -24,7 +24,8 @@ public class CreateMemberSnippet {
 		fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
 		fieldWithPath("handle").type(JsonFieldType.STRING).description("사용자 핸들 (고유 식별자, 예: @myhandle)"),
 		fieldWithPath("name").type(JsonFieldType.STRING).description("사용자 이름"),
-		fieldWithPath("motto").type(JsonFieldType.STRING).description("좌우명 또는 한 줄 소개")
+		fieldWithPath("motto").type(JsonFieldType.STRING).description("좌우명 또는 한 줄 소개"),
+		fieldWithPath("loginProvider").type(JsonFieldType.STRING).description("회원가입 시 사용한 로그인 제공자 예: EMAIL, GOOGLE, KAKAO")
 	);
 
 	private static final Snippet RESPONSE_FIELDS = responseFields(

--- a/src/test/java/com/gomo/app/member/unit/usecase/CreateMemberUseCaseTest.java
+++ b/src/test/java/com/gomo/app/member/unit/usecase/CreateMemberUseCaseTest.java
@@ -66,7 +66,8 @@ public class CreateMemberUseCaseTest {
 			member.getPassword().getPassword(),
 			member.getHandle().getHandle(),
 			member.getName().getName(),
-			member.getMotto().getMotto()
+			member.getMotto().getMotto(),
+			member.getLoginProvider()
 		));
 
 		assertThat(actual).usingRecursiveComparison().isEqualTo(CreateMemberResponse.of(member.getId()));


### PR DESCRIPTION
## 작업 사항

**JIRA TICKET:** #[GOMO-191](https://kkj1250.atlassian.net/browse/GOMO-191?atlOrigin=eyJpIjoiM2I3Yjk5OGJiYmQ4NGIxNzg3ZDRkMDQ4Y2EzMzQxNTkiLCJwIjoiaiJ9)

<br>

### 내용

- [x] OAuth기능 구현 관련햐여 Business Logic 변경으로 인한 리팩토링 수행하였습니다.
-- Flow는 아래와 같습니다.
>- Front 에서 소셜로그인(OAuth) 수행
>- OAuth Provider에서 code를 frontend로 리턴
>- 프론트 엔드에서 해당 code를 백엔드로 전송
-> 백엔드에서 해당 code를 사용하여 google에 accessToken을 발급받은 후, 사용자 정보를 습득
>- (이메일이 가입되어있을 시)
>-- 로그인 수행, accessToken과 refreshToken 발급 후 사용자 정보와 함께 전송
>- (이메일이 가입되어있지 않을 시)
>-- 사용자 정보 만 전송

[GOMO-191]: https://kkj1250.atlassian.net/browse/GOMO-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ